### PR TITLE
Fix IMU→sensor frame rotation in deskew

### DIFF
--- a/config/example_params.yaml
+++ b/config/example_params.yaml
@@ -41,7 +41,8 @@ polka:
     motion_compensation:
       enabled: false
       imu_topic: ""                  # sensor_msgs/Imu topic (empty = disabled)
-      max_imu_age: 0.2              # seconds - reject stale IMU data
+      imu_frame: ""                  # If empty use header.frame_id
+      max_imu_age: 0.2               # seconds - reject stale IMU data
       imu_buffer_size: 200           # ring buffer capacity (~1s at 200Hz)
       per_point_deskew: true         # per-point correction within each scan
                                      # requires per-point timestamps in PointCloud2

--- a/include/polka/polka_node.hpp
+++ b/include/polka/polka_node.hpp
@@ -88,6 +88,10 @@ private:
   std::vector<Eigen::Isometry3d> last_good_transforms_;
   std::vector<int> tf_fail_counts_;
 
+  // IMU→source frame rotation cache (for inter-source alignment)
+  std::vector<Eigen::Matrix3d> imu_to_source_rotations_;
+  std::vector<bool> imu_to_source_cached_;
+
   // Runtime reconfiguration
   ConfigLoader config_loader_;
   std::vector<std::string> source_names_;
@@ -98,6 +102,7 @@ private:
   std::deque<ImuSample> imu_buffer_;
   mutable std::mutex imu_mutex_;
   std::shared_ptr<const AveragedImu> imu_snapshot_;  // atomic-shared with SourceAdapters
+  std::string imu_frame_id_;
 
   // Stale data buffering - ensures publishing at specified frequency
   CloudT::Ptr last_cloud_;

--- a/include/polka/source_adapter.hpp
+++ b/include/polka/source_adapter.hpp
@@ -22,6 +22,7 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <laser_geometry/laser_geometry.hpp>
+#include <tf2_ros/buffer.h>
 
 #include <Eigen/Core>
 #include <functional>
@@ -40,7 +41,9 @@ public:
 
   SourceAdapter(rclcpp::Node * node, const SourceConfig & config, bool gpu_filters = false,
                 ImuGetter imu_getter = nullptr, bool deskew_enabled = false,
-                const std::string & timestamp_field_hint = "auto");
+                const std::string & timestamp_field_hint = "auto",
+                std::shared_ptr<tf2_ros::Buffer> tf_buffer = nullptr,
+                const std::string & imu_frame_id = "");
 
   CloudT::ConstPtr get_latest() const;
   bool is_stale(double timeout_sec, const rclcpp::Time & now) const;
@@ -50,6 +53,7 @@ public:
   uint64_t message_count() const { return message_counter_.load(); }
   const FilterParams & filter_params() const { return config_.filter_params; }
   void rebuild_filters(const FilterParams & fp);
+  void set_imu_frame_id(const std::string & frame_id);
 
 private:
   void pc2_callback(sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
@@ -61,6 +65,7 @@ private:
   // Per-point deskewing
   void detect_timestamp_field(const sensor_msgs::msg::PointCloud2 & msg);
   double extract_point_time(const uint8_t * point_data) const;
+  void cache_imu_rotation();
   void deskew_cloud(CloudT & cloud, const sensor_msgs::msg::PointCloud2 & raw_msg,
                     const AveragedImu & imu);
 
@@ -91,6 +96,11 @@ private:
   std::string timestamp_field_hint_{"auto"};
   bool timestamp_field_detected_{false};
   bool has_timestamp_field_{false};
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::string imu_frame_id_;
+  Eigen::Matrix3d R_imu_to_sensor_ = Eigen::Matrix3d::Identity();
+  bool imu_rotation_cached_ = false;
+
   uint32_t timestamp_field_offset_{0};
   uint8_t timestamp_field_datatype_{0};  // FLOAT32 or FLOAT64
 };

--- a/include/polka/types.hpp
+++ b/include/polka/types.hpp
@@ -166,6 +166,7 @@ struct MotionCompensationConfig {
   int imu_buffer_size = 200;                      // ring buffer capacity
   bool per_point_deskew = true;                   // per-point correction if timestamps available
   std::string deskew_timestamp_field = "auto";    // "auto" or specific field name
+  std::string imu_frame = "";                     // empty = auto-detect from IMU msg header
 };
 
 struct MergeConfig {

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -40,6 +40,7 @@ void ConfigLoader::declare_defaults()
   node_->declare_parameter<int>("motion_compensation.imu_buffer_size", 200);
   node_->declare_parameter<bool>("motion_compensation.per_point_deskew", true);
   node_->declare_parameter<std::string>("motion_compensation.deskew_timestamp_field", "auto");
+  node_->declare_parameter<std::string>("motion_compensation.imu_frame", "");
 
   // outputs.cloud
   node_->declare_parameter<bool>("outputs.cloud.enabled", true);
@@ -179,6 +180,8 @@ MergeConfig ConfigLoader::load()
     node_->get_parameter("motion_compensation.per_point_deskew").as_bool();
   cfg.motion_compensation.deskew_timestamp_field =
     node_->get_parameter("motion_compensation.deskew_timestamp_field").as_string();
+  cfg.motion_compensation.imu_frame =
+    node_->get_parameter("motion_compensation.imu_frame").as_string();
 
   // Cloud output
   cfg.cloud_output.enabled = node_->get_parameter("outputs.cloud.enabled").as_bool();
@@ -296,6 +299,8 @@ MergeConfig ConfigLoader::reload(const std::vector<std::string> & source_names)
     node_->get_parameter("motion_compensation.per_point_deskew").as_bool();
   cfg.motion_compensation.deskew_timestamp_field =
     node_->get_parameter("motion_compensation.deskew_timestamp_field").as_string();
+  cfg.motion_compensation.imu_frame =
+    node_->get_parameter("motion_compensation.imu_frame").as_string();
 
   cfg.cloud_output.enabled = node_->get_parameter("outputs.cloud.enabled").as_bool();
   cfg.cloud_output.topic = node_->get_parameter("outputs.cloud.topic").as_string();

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -54,7 +54,7 @@ rclcpp::QoS build_qos(const OutputQosConfig & cfg)
   else
     qos.durability(rclcpp::DurabilityPolicy::Volatile);
 
-  if (cfg.liveliness == "manual_by_topic")
+  if (cfg.liveliness == "manual_by_topic" || cfg.liveliness == "manual_by_node")
     qos.liveliness(rclcpp::LivelinessPolicy::ManualByTopic);
   else
     qos.liveliness(rclcpp::LivelinessPolicy::Automatic);
@@ -104,6 +104,8 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
   if (config_.motion_compensation.enabled)
     setup_imu_subscriber();
 
+  imu_frame_id_ = config_.motion_compensation.imu_frame;
+
   // IMU getter for source adapters (per-point deskewing)
   SourceAdapter::ImuGetter imu_getter = nullptr;
   if (config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew) {
@@ -117,10 +119,14 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
     sources_.push_back(std::make_unique<SourceAdapter>(
       this, src_cfg, gpu_filters, imu_getter,
       config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew,
-      config_.motion_compensation.deskew_timestamp_field));
+      config_.motion_compensation.deskew_timestamp_field,
+      config_.motion_compensation.enabled ? tf_buffer_ : nullptr,
+      imu_frame_id_));
 
   last_good_transforms_.resize(sources_.size(), Eigen::Isometry3d::Identity());
   tf_fail_counts_.resize(sources_.size(), 0);
+  imu_to_source_rotations_.resize(sources_.size(), Eigen::Matrix3d::Identity());
+  imu_to_source_cached_.resize(sources_.size(), false);
 
   build_output_filters();
 
@@ -178,6 +184,8 @@ void PolkaNode::output_callback()
     Eigen::Isometry3d transform;
     FilterParams filter_params;
     rclcpp::Time stamp;
+    std::string frame_id;
+    size_t source_index;
   };
   std::vector<SourceData> source_data;
 
@@ -208,7 +216,8 @@ void PolkaNode::output_callback()
       transform = last_good_transforms_[i];
     }
 
-    source_data.push_back({cloud, transform, src->filter_params(), src->last_stamp()});
+    source_data.push_back({cloud, transform, src->filter_params(), src->last_stamp(),
+                           src->frame_id(), i});
   }
 
   bool has_fresh_data = !source_data.empty();
@@ -268,8 +277,29 @@ void PolkaNode::output_callback()
     if (do_compensate) {
       double dt = (sd.stamp - output_stamp).seconds();
       if (std::abs(dt) > 1e-6) {
-        Eigen::Isometry3d delta = compute_motion_delta(
-          imu_for_alignment.angular_vel, imu_for_alignment.linear_accel, dt);
+        Eigen::Vector3d w = imu_for_alignment.angular_vel;
+        Eigen::Vector3d a = imu_for_alignment.linear_accel;
+
+        if (!imu_to_source_cached_[sd.source_index] && !imu_frame_id_.empty()) {
+          if (imu_frame_id_ == sd.frame_id) {
+            imu_to_source_cached_[sd.source_index] = true;
+          } else {
+            try {
+              auto tf_msg = tf_buffer_->lookupTransform(
+                sd.frame_id, imu_frame_id_, tf2::TimePointZero);
+              imu_to_source_rotations_[sd.source_index] =
+                tf2::transformToEigen(tf_msg.transform).rotation();
+              imu_to_source_cached_[sd.source_index] = true;
+            } catch (const tf2::TransformException &) {}
+          }
+        }
+
+        if (imu_to_source_cached_[sd.source_index]) {
+          w = imu_to_source_rotations_[sd.source_index] * w;
+          a = imu_to_source_rotations_[sd.source_index] * a;
+        }
+
+        Eigen::Isometry3d delta = compute_motion_delta(w, a, dt);
         final_transform = delta * sd.transform;
       }
     }
@@ -402,6 +432,14 @@ void PolkaNode::setup_imu_subscriber()
 
 void PolkaNode::imu_callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
 {
+  if (imu_frame_id_.empty() && !msg->header.frame_id.empty()) {
+    imu_frame_id_ = msg->header.frame_id;
+    RCLCPP_INFO(get_logger(), "motion compensation: auto-detected IMU frame '%s'",
+      imu_frame_id_.c_str());
+    for (auto & src : sources_)
+      src->set_imu_frame_id(imu_frame_id_);
+  }
+
   const auto & a = msg->linear_acceleration;
   const auto & w = msg->angular_velocity;
   if (!std::isfinite(a.x) || !std::isfinite(a.y) || !std::isfinite(a.z) ||

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -290,7 +290,11 @@ void PolkaNode::output_callback()
               imu_to_source_rotations_[sd.source_index] =
                 tf2::transformToEigen(tf_msg.transform).rotation();
               imu_to_source_cached_[sd.source_index] = true;
-            } catch (const tf2::TransformException &) {}
+            } catch (const tf2::TransformException & ex) {
+              RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000,
+                "IMU('%s') -> source('%s') TF not yet available: %s",
+                imu_frame_id_.c_str(), sd.frame_id.c_str(), ex.what());
+            }
           }
         }
 

--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -21,6 +21,7 @@
 
 #include <pcl_conversions/pcl_conversions.h>
 #include <sensor_msgs/msg/point_field.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
 
 #include <cstring>
 
@@ -28,10 +29,13 @@ namespace polka {
 
 SourceAdapter::SourceAdapter(rclcpp::Node * node, const SourceConfig & config, bool gpu_filters,
                              ImuGetter imu_getter, bool deskew_enabled,
-                             const std::string & timestamp_field_hint)
+                             const std::string & timestamp_field_hint,
+                             std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+                             const std::string & imu_frame_id)
 : node_(node), config_(config), logger_(node->get_logger()), gpu_filters_(gpu_filters),
   get_imu_(std::move(imu_getter)), deskew_enabled_(deskew_enabled),
-  timestamp_field_hint_(timestamp_field_hint)
+  timestamp_field_hint_(timestamp_field_hint),
+  tf_buffer_(std::move(tf_buffer)), imu_frame_id_(imu_frame_id)
 {
   // Build QoS
   rclcpp::QoS qos(config.qos_history_depth);
@@ -148,8 +152,15 @@ void SourceAdapter::deskew_cloud(
   size_t n = cloud.size();
   if (n == 0 || n != static_cast<size_t>(raw_msg.width) * raw_msg.height) return;
 
-  const Eigen::Vector3d angular_vel = imu.angular_vel;
-  const Eigen::Vector3d accel = imu.linear_accel;
+  cache_imu_rotation();
+
+  Eigen::Vector3d angular_vel = imu.angular_vel;
+  Eigen::Vector3d accel = imu.linear_accel;
+  if (imu_rotation_cached_) {
+    angular_vel = R_imu_to_sensor_ * angular_vel;
+    accel = R_imu_to_sensor_ * accel;
+  }
+
   const double header_sec = rclcpp::Time(raw_msg.header.stamp).seconds();
 
   const uint8_t * raw_data = raw_msg.data.data();
@@ -247,6 +258,40 @@ bool SourceAdapter::is_stale(double timeout_sec, const rclcpp::Time & now) const
 rclcpp::Time SourceAdapter::last_stamp() const
 {
   return last_received_time_;
+}
+
+void SourceAdapter::set_imu_frame_id(const std::string & frame_id)
+{
+  if (imu_frame_id_.empty() && !frame_id.empty()) {
+    imu_frame_id_ = frame_id;
+    imu_rotation_cached_ = false;
+  }
+}
+
+void SourceAdapter::cache_imu_rotation()
+{
+  if (imu_rotation_cached_ || imu_frame_id_.empty() || frame_id_.empty() || !tf_buffer_)
+    return;
+
+  if (imu_frame_id_ == frame_id_) {
+    R_imu_to_sensor_ = Eigen::Matrix3d::Identity();
+    imu_rotation_cached_ = true;
+    RCLCPP_INFO(logger_, "polka: source '%s' IMU frame == sensor frame ('%s'), no rotation needed",
+      config_.name.c_str(), frame_id_.c_str());
+    return;
+  }
+
+  try {
+    auto tf_msg = tf_buffer_->lookupTransform(frame_id_, imu_frame_id_, tf2::TimePointZero);
+    R_imu_to_sensor_ = tf2::transformToEigen(tf_msg.transform).rotation();
+    imu_rotation_cached_ = true;
+    RCLCPP_INFO(logger_, "polka: source '%s' cached IMU('%s') -> sensor('%s') rotation",
+      config_.name.c_str(), imu_frame_id_.c_str(), frame_id_.c_str());
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_WARN_THROTTLE(logger_, *node_->get_clock(), 5000,
+      "polka: source '%s' IMU('%s') -> sensor('%s') TF not yet available: %s",
+      config_.name.c_str(), imu_frame_id_.c_str(), frame_id_.c_str(), ex.what());
+  }
 }
 
 void SourceAdapter::rebuild_filters(const FilterParams & fp)


### PR DESCRIPTION
## Summary
- Both deskew paths (`deskew_cloud` and inter-source alignment) applied IMU-frame ω/a directly to sensor-frame points without rotating through the IMU→sensor extrinsic. On multi-LiDAR rigs, only the sensor coincidentally aligned with the IMU got correct deskew.
- Adds `imu_frame` config param (auto-detected from IMU `header.frame_id` when empty), looks up the rotation via TF once per source, caches it, and rotates ω and a into the sensor frame before `compute_motion_delta()`.

Cherry-pick of the Humble fix (#6) onto Jazzy.

Closes #3

## Changes
| File | What |
|---|---|
| `types.hpp` | Add `imu_frame` field to `MotionCompensationConfig` |
| `config_loader.cpp` | Declare + load `imu_frame` param |
| `source_adapter.hpp/cpp` | Extended ctor with `tf_buffer`/`imu_frame_id`, `cache_imu_rotation()`, rotation in `deskew_cloud()` |
| `polka_node.hpp/cpp` | Store `imu_frame_id_`, auto-detect from first IMU msg, per-source rotation in inter-source alignment |

## Test plan
- [ ] Build passes on Jazzy (`colcon build --packages-select polka`)
- [ ] Single-LiDAR rig with IMU aligned to sensor: identity rotation logged, no behavioral change
- [ ] Multi-LiDAR rig with IMU misaligned: each source logs cached rotation, deskew output matches ground truth
- [ ] `imu_frame: ""` auto-detects from IMU header; explicit `imu_frame: "imu_link"` works
- [ ] TF not yet available on startup: warns, retries, caches on first success