### PR TITLE
Subtract gravity from IMU acceleration in deskew model

### DIFF
--- a/<path to file affected by the commit>
+++ b/<path to file affected by the commit>
@@ -1,1 +1,0 @@
-<commit changes or content>

--- a/<path to file affected by the commit>
+++ b/<path to file affected by the commit>
@@ -1,0 +1,1 @@
+<commit changes or content>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.8)
 project(polka)
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # POLKA
 
 <p align="center">
-  <img src="images/polka.png" alt="Polka" width="300"/>
+  <img src="images/polka.png" alt="Polka" width="700"/>
 </p>
 
 **Multi-LiDAR fusion node for ROS 2** that merges any mix of PointCloud2 and LaserScan sources into a unified output, with optional CUDA GPU acceleration.

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -421,6 +421,11 @@ void PolkaNode::imu_callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
       Eigen::Vector3d g_imu =
         ori.toRotationMatrix().transpose() * Eigen::Vector3d(0.0, 0.0, kGravity);
       accel -= g_imu;
+    } else {
+      accel.setZero();
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000,
+        "motion compensation: degenerate IMU orientation quaternion, "
+        "translation deskew disabled");
     }
   } else {
     accel.setZero();

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -411,9 +411,27 @@ void PolkaNode::imu_callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
     return;
   }
 
+  Eigen::Vector3d accel(a.x, a.y, a.z);
+  if (msg->orientation_covariance[0] >= 0.0) {
+    const auto & q = msg->orientation;
+    Eigen::Quaterniond ori(q.w, q.x, q.y, q.z);
+    if (ori.squaredNorm() > 0.5) {
+      ori.normalize();
+      constexpr double kGravity = 9.80665;
+      Eigen::Vector3d g_imu =
+        ori.toRotationMatrix().transpose() * Eigen::Vector3d(0.0, 0.0, kGravity);
+      accel -= g_imu;
+    }
+  } else {
+    accel.setZero();
+    RCLCPP_WARN_ONCE(get_logger(),
+      "motion compensation: IMU has no orientation — "
+      "cannot subtract gravity, translation deskew disabled (rotation-only)");
+  }
+
   ImuSample sample;
   sample.wx = w.x;  sample.wy = w.y;  sample.wz = w.z;
-  sample.ax = a.x;  sample.ay = a.y;  sample.az = a.z;
+  sample.ax = accel.x();  sample.ay = accel.y();  sample.az = accel.z();
   sample.stamp = rclcpp::Time(msg->header.stamp);
 
   {
@@ -423,12 +441,9 @@ void PolkaNode::imu_callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
       imu_buffer_.pop_front();
   }
 
-  // Update the atomic snapshot with the latest single-sample average
-  // (SourceAdapters use this as a best-effort fallback when the full
-  //  average_imu() isn't called from the output_callback path)
   auto avg = std::make_shared<AveragedImu>();
   avg->angular_vel = Eigen::Vector3d(w.x, w.y, w.z);
-  avg->linear_accel = Eigen::Vector3d(a.x, a.y, a.z);
+  avg->linear_accel = accel;
   avg->valid = true;
   std::atomic_store(&imu_snapshot_, std::const_pointer_cast<const AveragedImu>(avg));
 }


### PR DESCRIPTION
## Summary

- When IMU orientation is available (covariance[0] >= 0), rotate the gravity vector into the IMU frame and subtract it from the raw accelerometer reading before storing the sample. This prevents ~9.8 m/s^2 of gravity from contaminating the translational deskew.
- When the IMU has no orientation (covariance[0] < 0), zero out the acceleration and log a one-time warning, falling back to rotation-only deskew.

Closes #5

## Test plan

- [ ] Verify with an IMU that publishes orientation (e.g. BNO055, Xsens): deskewed cloud should no longer show vertical smearing from gravity leaking into translation compensation
- [ ] Verify with an IMU that does not publish orientation: node should log the warning once and produce rotation-only deskew without translation artifacts
- [ ] Confirm no regressions when motion compensation is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)