### PR TITLE
Warn on missing intensity field instead of silently zeroing

### DIFF
--- a/include/polka/source_adapter.hpp
+++ b/include/polka/source_adapter.hpp
@@ -81,6 +81,7 @@ private:
   laser_geometry::LaserProjection projector_;
   bool fields_validated_{false};
   bool fields_valid_{false};
+  bool missing_intensity_{false};
 
   std::vector<std::unique_ptr<IFilter>> filters_;
   bool gpu_filters_{false};

--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -86,11 +86,6 @@ bool SourceAdapter::validate_fields(const sensor_msgs::msg::PointCloud2 & msg)
     return false;
   }
   missing_intensity_ = !has_intensity;
-  if (missing_intensity_) {
-    RCLCPP_WARN(logger_,
-      "polka: source '%s' missing 'intensity' field - publishing with intensity=0",
-      config_.name.c_str());
-  }
   return true;
 }
 

--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -72,17 +72,24 @@ SourceAdapter::SourceAdapter(rclcpp::Node * node, const SourceConfig & config, b
 
 bool SourceAdapter::validate_fields(const sensor_msgs::msg::PointCloud2 & msg)
 {
-  bool has_x = false, has_y = false, has_z = false;
+  bool has_x = false, has_y = false, has_z = false, has_intensity = false;
   for (const auto & field : msg.fields) {
     if (field.name == "x" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) has_x = true;
     if (field.name == "y" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) has_y = true;
     if (field.name == "z" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) has_z = true;
+    if (field.name == "intensity") has_intensity = true;
   }
   if (!has_x || !has_y || !has_z) {
     RCLCPP_ERROR(logger_,
       "polka: source '%s' missing required FLOAT32 x/y/z fields - dropping all messages",
       config_.name.c_str());
     return false;
+  }
+  missing_intensity_ = !has_intensity;
+  if (missing_intensity_) {
+    RCLCPP_WARN(logger_,
+      "polka: source '%s' missing 'intensity' field - publishing with intensity=0",
+      config_.name.c_str());
   }
   return true;
 }
@@ -196,6 +203,12 @@ void SourceAdapter::pc2_callback(sensor_msgs::msg::PointCloud2::ConstSharedPtr m
     fields_valid_ = validate_fields(*msg);
   }
   if (!fields_valid_) return;
+
+  if (missing_intensity_) {
+    RCLCPP_WARN_THROTTLE(logger_, *node_->get_clock(), 10000,
+      "polka: source '%s' missing 'intensity' field - publishing with intensity=0",
+      config_.name.c_str());
+  }
 
   // Detect per-point timestamp field on first message
   if (!timestamp_field_detected_)


### PR DESCRIPTION
## Summary
- PointCloud2 sources without an `intensity` field previously had intensity silently filled with 0.0 by `pcl::fromROSMsg`. No indication was given to the operator.
- Now `validate_fields()` detects the missing field on first message, and `pc2_callback()` logs a throttled warning every 10s so operators know data quality is degraded.
- Pipeline continues publishing — intensity is non-critical (x/y/z remain hard requirements).

Cherry-pick of #9 onto Jazzy.

## Test plan
- [ ] Source with intensity: no warnings, normal behavior
- [ ] Source without intensity: warning on first message + every 10s, cloud still published with intensity=0
- [ ] LaserScan sources unaffected (`projectLaser` always generates intensity)