### PR TITLE
Subtract gravity from IMU acceleration in deskew model (Jazzy)

### DIFF
--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -411,9 +411,27 @@ void PolkaNode::imu_callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
     return;
   }
 
+  Eigen::Vector3d accel(a.x, a.y, a.z);
+  if (msg->orientation_covariance[0] >= 0.0) {
+    const auto & q = msg->orientation;
+    Eigen::Quaterniond ori(q.w, q.x, q.y, q.z);
+    if (ori.squaredNorm() > 0.5) {
+      ori.normalize();
+      constexpr double kGravity = 9.80665;
+      Eigen::Vector3d g_imu =
+        ori.toRotationMatrix().transpose() * Eigen::Vector3d(0.0, 0.0, kGravity);
+      accel -= g_imu;
+    }
+  } else {
+    accel.setZero();
+    RCLCPP_WARN_ONCE(get_logger(),
+      "motion compensation: IMU has no orientation — "
+      "cannot subtract gravity, translation deskew disabled (rotation-only)");
+  }
+
   ImuSample sample;
   sample.wx = w.x;  sample.wy = w.y;  sample.wz = w.z;
-  sample.ax = a.x;  sample.ay = a.y;  sample.az = a.z;
+  sample.ax = accel.x();  sample.ay = accel.y();  sample.az = accel.z();
   sample.stamp = rclcpp::Time(msg->header.stamp);
 
   {
@@ -423,12 +441,9 @@ void PolkaNode::imu_callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
       imu_buffer_.pop_front();
   }
 
-  // Update the atomic snapshot with the latest single-sample average
-  // (SourceAdapters use this as a best-effort fallback when the full
-  //  average_imu() isn't called from the output_callback path)
   auto avg = std::make_shared<AveragedImu>();
   avg->angular_vel = Eigen::Vector3d(w.x, w.y, w.z);
-  avg->linear_accel = Eigen::Vector3d(a.x, a.y, a.z);
+  avg->linear_accel = accel;
   avg->valid = true;
   std::atomic_store(&imu_snapshot_, std::const_pointer_cast<const AveragedImu>(avg));
 }


### PR DESCRIPTION
## Summary
- Subtract gravity from raw IMU acceleration in `imu_callback` before storing samples, using the IMU's reported orientation quaternion to rotate the gravity vector into the sensor frame
- When the IMU does not provide orientation (`orientation_covariance[0] < 0`), zero out linear acceleration and log a one-time warning indicating rotation-only deskew
- Prevents gravity contamination from causing spurious translational corrections during point cloud motion compensation

Closes #5

## Test plan
- [ ] Verify deskew output with an IMU that provides orientation (e.g. BNO055, VN-100): confirm the compensated acceleration is near-zero when stationary
- [ ] Test with an IMU that does not publish orientation (covariance[0] == -1): confirm the warning is logged once and translation deskew is disabled gracefully
- [ ] Compare merged point cloud quality before/after on a dataset with aggressive rotation to confirm reduced drift artifacts