### PR TITLE
Subtract gravity from IMU acceleration in deskew model

### DIFF
--- a/<path to file affected by the commit>
+++ b/<path to file affected by the commit>
@@ -1,1 +1,0 @@
-<commit changes or content>

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -463,6 +463,11 @@ void PolkaNode::imu_callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
       Eigen::Vector3d g_imu =
         ori.toRotationMatrix().transpose() * Eigen::Vector3d(0.0, 0.0, kGravity);
       accel -= g_imu;
+    } else {
+      accel.setZero();
+      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000,
+        "motion compensation: degenerate IMU orientation quaternion, "
+        "translation deskew disabled");
     }
   } else {
     accel.setZero();


### PR DESCRIPTION
## Summary
- Subtracts gravitational acceleration from IMU readings using the orientation quaternion before feeding into the deskew motion model. Without this, the ~9.8 m/s² gravity component causes spurious translation in `compute_motion_delta()`.
- When orientation is unavailable (`orientation_covariance[0] < 0`), zeros acceleration and falls back to rotation-only deskew.
- Fixes degenerate quaternion fallthrough: garbage orientation (`squaredNorm <= 0.5`) now zeros acceleration instead of passing raw gravity-contaminated data.
- Removes accidental template artifact file.

Cherry-pick of #8 onto Jazzy.

Closes #5

## Test plan
- [ ] IMU with valid orientation: gravity subtracted, near-zero accel at rest
- [ ] IMU without orientation (`orientation_covariance[0] = -1`): warns once, rotation-only deskew
- [ ] Degenerate quaternion: throttled warning, acceleration zeroed
- [ ] Tilted IMU: gravity correctly rotated into IMU frame before subtraction