### PR TITLE
Add per-source IMU override and code review fixes (Jazzy)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ include_directories(include ${PCL_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
 
 set(POLKA_CORE_SOURCES
   src/config_loader.cpp
+  src/imu_buffer.cpp
   src/filters/range_filter.cpp
   src/filters/angular_filter.cpp
   src/filters/box_filter.cpp

--- a/README.md
+++ b/README.md
@@ -108,12 +108,28 @@ The motion model is inspired by [rko_lio](https://github.com/TixiaoShan/rko_lio)
 ```yaml
 motion_compensation:
   enabled: true
-  imu_topic: "/imu/data"          # sensor_msgs/Imu topic
+  imu_topic: "/imu/data"          # sensor_msgs/Imu topic (global, used by all sources)
   max_imu_age: 0.2                # seconds - reject stale IMU
   imu_buffer_size: 200            # ring buffer (~1s at 200Hz)
   per_point_deskew: true          # per-point correction within each scan
   deskew_timestamp_field: "auto"  # auto-detects 'time', 't', 'timestamp', etc.
 ```
+
+#### Per-Source IMU Override
+
+Articulated platforms (hinged vehicles, manipulators, humanoids) can override the IMU on a per-source basis. Each source uses TF to rotate its IMU's angular velocity into the sensor frame, so `robot_state_publisher` must keep the IMU-to-sensor transform current.
+
+```yaml
+sources:
+  front_3d:
+    topic: "/front_lidar/points"
+    imu_topic: "/front_lidar/imu"   # integrated IMU on front segment
+  rear_2d:
+    topic: "/rear_lidar/scan"
+    # imu_topic omitted — falls back to motion_compensation.imu_topic
+```
+
+The global `motion_compensation.imu_topic` remains the recommended path for rigid platforms.
 
 ### Output Filters
 

--- a/config/example_params.yaml
+++ b/config/example_params.yaml
@@ -180,6 +180,9 @@ polka:
       front_3d:
         topic: "/front_lidar/points"
         type: "pointcloud2"
+        # imu_topic: "/front_lidar/imu" # per-source IMU override (empty or omitted = use global)
+                                        # useful for articulated platforms where each LiDAR
+                                        # has its own IMU; global IMU recommended for rigid platforms
         qos_reliability: "best_effort"   # "best_effort" or "reliable"
         qos_history_depth: 1
         filters:
@@ -201,6 +204,7 @@ polka:
       rear_2d:
         topic: "/rear_lidar/scan"
         type: "laserscan"
+        # imu_topic: ""                  # falls back to motion_compensation.imu_topic
         qos_reliability: "best_effort"
         qos_history_depth: 1
         filters:

--- a/include/polka/config_loader.hpp
+++ b/include/polka/config_loader.hpp
@@ -31,6 +31,7 @@ private:
   rclcpp::Logger logger_;
 
   void declare_defaults();
+  MergeConfig read_common_params();
   FilterParams load_filter_params(const std::string & prefix);
   OutputQosConfig load_output_qos(const std::string & prefix);
   SelfFilterConfig load_self_filter_config(const std::string & prefix);

--- a/include/polka/imu_buffer.hpp
+++ b/include/polka/imu_buffer.hpp
@@ -1,0 +1,62 @@
+// Copyright 2025 Panav Arpit Raaj <praajarpit@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POLKA__IMU_BUFFER_HPP
+#define POLKA__IMU_BUFFER_HPP
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <Eigen/Core>
+
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace polka {
+
+struct ImuSample {
+  double wx = 0.0, wy = 0.0, wz = 0.0;   // angular velocity (rad/s)
+  double ax = 0.0, ay = 0.0, az = 0.0;    // linear acceleration (m/s²)
+  rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
+};
+
+struct AveragedImu {
+  Eigen::Vector3d angular_vel = Eigen::Vector3d::Zero();
+  Eigen::Vector3d linear_accel = Eigen::Vector3d::Zero();
+  bool valid = false;
+  std::string frame_id;
+};
+
+class ImuBuffer {
+public:
+  ImuBuffer(rclcpp::Node * node, const std::string & topic, int buffer_size);
+
+  std::shared_ptr<const AveragedImu> snapshot() const;
+
+private:
+  void callback(sensor_msgs::msg::Imu::ConstSharedPtr msg);
+
+  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr sub_;
+  std::deque<ImuSample> buffer_;
+  mutable std::mutex mutex_;
+  std::shared_ptr<const AveragedImu> snapshot_;
+  int max_size_;
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
+};
+
+}  // namespace polka
+
+#endif  // POLKA__IMU_BUFFER_HPP

--- a/include/polka/polka_node.hpp
+++ b/include/polka/polka_node.hpp
@@ -18,36 +18,23 @@
 #include "polka/types.hpp"
 #include "polka/config_loader.hpp"
 #include "polka/source_adapter.hpp"
+#include "polka/imu_buffer.hpp"
 #include "polka/merge_engine/i_merge_engine.hpp"
 #include "polka/filters/i_filter.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
-#include <sensor_msgs/msg/imu.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <Eigen/Geometry>
 
-#include <deque>
 #include <memory>
 #include <vector>
 #include <string>
 #include <mutex>
 
 namespace polka {
-
-struct ImuSample {
-  double wx = 0.0, wy = 0.0, wz = 0.0;   // angular velocity (rad/s)
-  double ax = 0.0, ay = 0.0, az = 0.0;    // linear acceleration (m/s²)
-  rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
-};
-
-struct AveragedImu {
-  Eigen::Vector3d angular_vel = Eigen::Vector3d::Zero();
-  Eigen::Vector3d linear_accel = Eigen::Vector3d::Zero();
-  bool valid = false;
-};
 
 class PolkaNode : public rclcpp::Node {
 public:
@@ -65,9 +52,7 @@ private:
   void voxel_downsample(CloudT & cloud);
   void height_cap(CloudT & cloud);
 
-  // IMU-based motion compensation
-  void setup_imu_subscriber();
-  void imu_callback(sensor_msgs::msg::Imu::ConstSharedPtr msg);
+  // IMU-based motion compensation (global)
 
   MergeConfig config_;
 
@@ -87,21 +72,13 @@ private:
   std::vector<Eigen::Isometry3d> last_good_transforms_;
   std::vector<int> tf_fail_counts_;
 
-  // IMU→source frame rotation cache (for inter-source alignment)
-  std::vector<Eigen::Matrix3d> imu_to_source_rotations_;
-  std::vector<bool> imu_to_source_cached_;
-
   // Runtime reconfiguration
   ConfigLoader config_loader_;
   std::vector<std::string> source_names_;
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr param_cb_;
 
-  // IMU ring buffer and subscription
-  rclcpp::Subscription<sensor_msgs::msg::Imu>::SharedPtr imu_sub_;
-  std::deque<ImuSample> imu_buffer_;
-  mutable std::mutex imu_mutex_;
-  std::shared_ptr<const AveragedImu> imu_snapshot_;  // atomic-shared with SourceAdapters
-  std::string imu_frame_id_;
+  // Global IMU buffer (shared with SourceAdapters that don't have per-source IMU)
+  std::shared_ptr<ImuBuffer> global_imu_;
 
   // Stale data buffering - ensures publishing at specified frequency
   CloudT::Ptr last_cloud_;

--- a/include/polka/polka_node.hpp
+++ b/include/polka/polka_node.hpp
@@ -68,7 +68,6 @@ private:
   // IMU-based motion compensation
   void setup_imu_subscriber();
   void imu_callback(sensor_msgs::msg::Imu::ConstSharedPtr msg);
-  AveragedImu average_imu(const rclcpp::Time & start, const rclcpp::Time & end) const;
 
   MergeConfig config_;
 

--- a/include/polka/source_adapter.hpp
+++ b/include/polka/source_adapter.hpp
@@ -16,6 +16,7 @@
 #define POLKA__SOURCE_ADAPTER_HPP
 
 #include "polka/types.hpp"
+#include "polka/imu_buffer.hpp"
 #include "polka/filters/i_filter.hpp"
 
 #include <rclcpp/rclcpp.hpp>
@@ -34,8 +35,6 @@
 
 namespace polka {
 
-struct AveragedImu;  // forward declaration
-
 class SourceAdapter {
 public:
   using ImuGetter = std::function<std::shared_ptr<const AveragedImu>()>;
@@ -44,7 +43,7 @@ public:
                 ImuGetter imu_getter = nullptr, bool deskew_enabled = false,
                 const std::string & timestamp_field_hint = "auto",
                 std::shared_ptr<tf2_ros::Buffer> tf_buffer = nullptr,
-                const std::string & imu_frame_id = "");
+                int imu_buffer_size = 200);
 
   CloudT::ConstPtr get_latest() const;
   bool is_stale(double timeout_sec, const rclcpp::Time & now) const;
@@ -54,7 +53,6 @@ public:
   uint64_t message_count() const { return message_counter_.load(); }
   const FilterParams & filter_params() const { return config_.filter_params; }
   void rebuild_filters(const FilterParams & fp);
-  void set_imu_frame_id(const std::string & frame_id);
 
 private:
   void pc2_callback(sensor_msgs::msg::PointCloud2::ConstSharedPtr msg);
@@ -66,7 +64,6 @@ private:
   // Per-point deskewing
   void detect_timestamp_field(const sensor_msgs::msg::PointCloud2 & msg);
   double extract_point_time(const uint8_t * point_data) const;
-  void cache_imu_rotation();
   void deskew_cloud(CloudT & cloud, const sensor_msgs::msg::PointCloud2 & raw_msg,
                     const AveragedImu & imu);
 
@@ -99,13 +96,12 @@ private:
   std::string timestamp_field_hint_{"auto"};
   bool timestamp_field_detected_{false};
   bool has_timestamp_field_{false};
-  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-  std::string imu_frame_id_;
-  Eigen::Matrix3d R_imu_to_sensor_ = Eigen::Matrix3d::Identity();
-  bool imu_rotation_cached_ = false;
-
   uint32_t timestamp_field_offset_{0};
   uint8_t timestamp_field_datatype_{0};  // FLOAT32 or FLOAT64
+
+  // Per-source IMU (when configured) and TF for frame rotation
+  std::shared_ptr<ImuBuffer> local_imu_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
 };
 
 }  // namespace polka

--- a/include/polka/source_adapter.hpp
+++ b/include/polka/source_adapter.hpp
@@ -27,6 +27,7 @@
 #include <Eigen/Core>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 #include <atomic>
@@ -49,7 +50,7 @@ public:
   bool is_stale(double timeout_sec, const rclcpp::Time & now) const;
   rclcpp::Time last_stamp() const;
   std::string name() const { return config_.name; }
-  std::string frame_id() const { return frame_id_; }
+  std::string frame_id() const;
   uint64_t message_count() const { return message_counter_.load(); }
   const FilterParams & filter_params() const { return config_.filter_params; }
   void rebuild_filters(const FilterParams & fp);
@@ -77,6 +78,7 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
 
   std::shared_ptr<CloudT> buffer_;
+  mutable std::mutex meta_mutex_;
   rclcpp::Time last_received_time_;
   std::string frame_id_;
 

--- a/include/polka/types.hpp
+++ b/include/polka/types.hpp
@@ -102,6 +102,7 @@ struct FlattenParams {
 struct SourceConfig {
   std::string name;
   std::string topic;
+  std::string imu_topic;  // per-source IMU override (empty = use global)
   SourceType type = SourceType::POINTCLOUD2;
   std::string qos_reliability = "best_effort";
   int qos_history_depth = 1;

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -151,7 +151,7 @@ FilterParams ConfigLoader::load_filter_params(const std::string & prefix)
   return fp;
 }
 
-MergeConfig ConfigLoader::load()
+MergeConfig ConfigLoader::read_common_params()
 {
   MergeConfig cfg;
   cfg.output_frame_id = node_->get_parameter("output_frame_id").as_string();
@@ -167,7 +167,6 @@ MergeConfig ConfigLoader::load()
   else if (ts_str == "local") cfg.timestamp_strategy = TimestampStrategy::LOCAL;
   else throw std::runtime_error("polka: invalid timestamp_strategy '" + ts_str + "'");
 
-  // Motion compensation (IMU-based deskewing)
   cfg.motion_compensation.enabled =
     node_->get_parameter("motion_compensation.enabled").as_bool();
   cfg.motion_compensation.imu_topic =
@@ -183,13 +182,11 @@ MergeConfig ConfigLoader::load()
   cfg.motion_compensation.imu_frame =
     node_->get_parameter("motion_compensation.imu_frame").as_string();
 
-  // Cloud output
   cfg.cloud_output.enabled = node_->get_parameter("outputs.cloud.enabled").as_bool();
   cfg.cloud_output.topic = node_->get_parameter("outputs.cloud.topic").as_string();
   cfg.cloud_output.qos = load_output_qos("outputs.cloud.qos");
   cfg.cloud_output.filters = load_filter_params("outputs.cloud.filters");
 
-  // Voxel config
   {
     double uniform = node_->get_parameter("outputs.cloud.voxel.leaf_size").as_double();
     double lx = node_->get_parameter("outputs.cloud.voxel.leaf_x").as_double();
@@ -205,7 +202,6 @@ MergeConfig ConfigLoader::load()
       (lx > 0.0 && ly > 0.0 && lz > 0.0);
   }
 
-  // Height cap config
   cfg.cloud_output.height_cap.enabled =
     node_->get_parameter("outputs.cloud.height_cap.enabled").as_bool();
   cfg.cloud_output.height_cap.z_min =
@@ -213,10 +209,6 @@ MergeConfig ConfigLoader::load()
   cfg.cloud_output.height_cap.z_max =
     node_->get_parameter("outputs.cloud.height_cap.z_max").as_double();
 
-  // Self-filter config
-  cfg.cloud_output.self_filter = load_self_filter_config("outputs.cloud.self_filter");
-
-  // Scan output
   cfg.scan_output.enabled = node_->get_parameter("outputs.scan.enabled").as_bool();
   cfg.scan_output.topic = node_->get_parameter("outputs.scan.topic").as_string();
   cfg.scan_output.qos = load_output_qos("outputs.scan.qos");
@@ -230,7 +222,15 @@ MergeConfig ConfigLoader::load()
   cfg.scan_output.flatten.compute_bins();
   cfg.scan_output.flatten.validate();
 
-  // Sources
+  return cfg;
+}
+
+MergeConfig ConfigLoader::load()
+{
+  MergeConfig cfg = read_common_params();
+
+  cfg.cloud_output.self_filter = load_self_filter_config("outputs.cloud.self_filter");
+
   auto source_names = node_->get_parameter("source_names").as_string_array();
   for (const auto & name : source_names) {
     std::string p = "sources." + name;
@@ -272,66 +272,8 @@ MergeConfig ConfigLoader::load()
 
 MergeConfig ConfigLoader::reload(const std::vector<std::string> & source_names)
 {
-  MergeConfig cfg;
-  cfg.output_frame_id = node_->get_parameter("output_frame_id").as_string();
-  cfg.output_rate = node_->get_parameter("output_rate").as_double();
-  cfg.source_timeout = node_->get_parameter("source_timeout").as_double();
-  cfg.enable_gpu = node_->get_parameter("enable_gpu").as_bool();
-  cfg.max_source_spread_warn = node_->get_parameter("max_source_spread_warn").as_double();
+  MergeConfig cfg = read_common_params();
 
-  auto ts_str = node_->get_parameter("timestamp_strategy").as_string();
-  if (ts_str == "earliest") cfg.timestamp_strategy = TimestampStrategy::EARLIEST;
-  else if (ts_str == "latest") cfg.timestamp_strategy = TimestampStrategy::LATEST;
-  else if (ts_str == "average") cfg.timestamp_strategy = TimestampStrategy::AVERAGE;
-  else if (ts_str == "local") cfg.timestamp_strategy = TimestampStrategy::LOCAL;
-  else throw std::runtime_error("polka: invalid timestamp_strategy '" + ts_str + "'");
-
-  // Motion compensation (IMU-based deskewing)
-  cfg.motion_compensation.enabled =
-    node_->get_parameter("motion_compensation.enabled").as_bool();
-  cfg.motion_compensation.imu_topic =
-    node_->get_parameter("motion_compensation.imu_topic").as_string();
-  cfg.motion_compensation.max_imu_age =
-    node_->get_parameter("motion_compensation.max_imu_age").as_double();
-  cfg.motion_compensation.imu_buffer_size =
-    node_->get_parameter("motion_compensation.imu_buffer_size").as_int();
-  cfg.motion_compensation.per_point_deskew =
-    node_->get_parameter("motion_compensation.per_point_deskew").as_bool();
-  cfg.motion_compensation.deskew_timestamp_field =
-    node_->get_parameter("motion_compensation.deskew_timestamp_field").as_string();
-  cfg.motion_compensation.imu_frame =
-    node_->get_parameter("motion_compensation.imu_frame").as_string();
-
-  cfg.cloud_output.enabled = node_->get_parameter("outputs.cloud.enabled").as_bool();
-  cfg.cloud_output.topic = node_->get_parameter("outputs.cloud.topic").as_string();
-  cfg.cloud_output.qos = load_output_qos("outputs.cloud.qos");
-  cfg.cloud_output.filters = load_filter_params("outputs.cloud.filters");
-
-  // Voxel config
-  {
-    double uniform = node_->get_parameter("outputs.cloud.voxel.leaf_size").as_double();
-    double lx = node_->get_parameter("outputs.cloud.voxel.leaf_x").as_double();
-    double ly = node_->get_parameter("outputs.cloud.voxel.leaf_y").as_double();
-    double lz = node_->get_parameter("outputs.cloud.voxel.leaf_z").as_double();
-    if (uniform > 0.0 && lx == 0.0 && ly == 0.0 && lz == 0.0)
-      lx = ly = lz = uniform;
-    cfg.cloud_output.voxel.leaf_x = static_cast<float>(lx);
-    cfg.cloud_output.voxel.leaf_y = static_cast<float>(ly);
-    cfg.cloud_output.voxel.leaf_z = static_cast<float>(lz);
-    cfg.cloud_output.voxel.enabled =
-      node_->get_parameter("outputs.cloud.voxel.enabled").as_bool() ||
-      (lx > 0.0 && ly > 0.0 && lz > 0.0);
-  }
-
-  // Height cap config
-  cfg.cloud_output.height_cap.enabled =
-    node_->get_parameter("outputs.cloud.height_cap.enabled").as_bool();
-  cfg.cloud_output.height_cap.z_min =
-    node_->get_parameter("outputs.cloud.height_cap.z_min").as_double();
-  cfg.cloud_output.height_cap.z_max =
-    node_->get_parameter("outputs.cloud.height_cap.z_max").as_double();
-
-  // Self-filter config (box params already declared in load())
   cfg.cloud_output.self_filter.enabled =
     node_->get_parameter("outputs.cloud.self_filter.enabled").as_bool();
   if (cfg.cloud_output.self_filter.enabled) {
@@ -349,19 +291,6 @@ MergeConfig ConfigLoader::reload(const std::vector<std::string> & source_names)
       cfg.cloud_output.self_filter.boxes.push_back(box);
     }
   }
-
-  cfg.scan_output.enabled = node_->get_parameter("outputs.scan.enabled").as_bool();
-  cfg.scan_output.topic = node_->get_parameter("outputs.scan.topic").as_string();
-  cfg.scan_output.qos = load_output_qos("outputs.scan.qos");
-  cfg.scan_output.flatten.z_min = node_->get_parameter("outputs.scan.z_min").as_double();
-  cfg.scan_output.flatten.z_max = node_->get_parameter("outputs.scan.z_max").as_double();
-  cfg.scan_output.flatten.angle_min = node_->get_parameter("outputs.scan.angle_min").as_double();
-  cfg.scan_output.flatten.angle_max = node_->get_parameter("outputs.scan.angle_max").as_double();
-  cfg.scan_output.flatten.angle_increment = node_->get_parameter("outputs.scan.angle_increment").as_double();
-  cfg.scan_output.flatten.range_min = node_->get_parameter("outputs.scan.range_min").as_double();
-  cfg.scan_output.flatten.range_max = node_->get_parameter("outputs.scan.range_max").as_double();
-  cfg.scan_output.flatten.compute_bins();
-  cfg.scan_output.flatten.validate();
 
   for (const auto & name : source_names) {
     std::string p = "sources." + name;

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -236,6 +236,7 @@ MergeConfig ConfigLoader::load()
     std::string p = "sources." + name;
 
     node_->declare_parameter<std::string>(p + ".topic", "");
+    node_->declare_parameter<std::string>(p + ".imu_topic", "");
     node_->declare_parameter<std::string>(p + ".type", "pointcloud2");
     node_->declare_parameter<std::string>(p + ".qos_reliability", "best_effort");
     node_->declare_parameter<int>(p + ".qos_history_depth", 1);
@@ -256,6 +257,7 @@ MergeConfig ConfigLoader::load()
     SourceConfig sc;
     sc.name = name;
     sc.topic = node_->get_parameter(p + ".topic").as_string();
+    sc.imu_topic = node_->get_parameter(p + ".imu_topic").as_string();
     auto type_str = node_->get_parameter(p + ".type").as_string();
     sc.type = (type_str == "laserscan") ? SourceType::LASERSCAN : SourceType::POINTCLOUD2;
     sc.qos_reliability = node_->get_parameter(p + ".qos_reliability").as_string();
@@ -297,6 +299,7 @@ MergeConfig ConfigLoader::reload(const std::vector<std::string> & source_names)
     SourceConfig sc;
     sc.name = name;
     sc.topic = node_->get_parameter(p + ".topic").as_string();
+    sc.imu_topic = node_->get_parameter(p + ".imu_topic").as_string();
     auto type_str = node_->get_parameter(p + ".type").as_string();
     sc.type = (type_str == "laserscan") ? SourceType::LASERSCAN : SourceType::POINTCLOUD2;
     sc.qos_reliability = node_->get_parameter(p + ".qos_reliability").as_string();

--- a/src/imu_buffer.cpp
+++ b/src/imu_buffer.cpp
@@ -1,0 +1,88 @@
+// Copyright 2025 Panav Arpit Raaj <praajarpit@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "polka/imu_buffer.hpp"
+#include <Eigen/Geometry>
+#include <cmath>
+
+namespace polka {
+
+ImuBuffer::ImuBuffer(rclcpp::Node * node, const std::string & topic, int buffer_size)
+: max_size_(buffer_size), logger_(node->get_logger()), clock_(node->get_clock())
+{
+  sub_ = node->create_subscription<sensor_msgs::msg::Imu>(
+    topic, rclcpp::SensorDataQoS(),
+    std::bind(&ImuBuffer::callback, this, std::placeholders::_1));
+  RCLCPP_INFO(logger_, "IMU buffer: subscribing to '%s' (capacity %d)", topic.c_str(), buffer_size);
+}
+
+std::shared_ptr<const AveragedImu> ImuBuffer::snapshot() const
+{
+  return std::atomic_load(&snapshot_);
+}
+
+void ImuBuffer::callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
+{
+  const auto & a = msg->linear_acceleration;
+  const auto & w = msg->angular_velocity;
+  if (!std::isfinite(a.x) || !std::isfinite(a.y) || !std::isfinite(a.z) ||
+      !std::isfinite(w.x) || !std::isfinite(w.y) || !std::isfinite(w.z)) {
+    RCLCPP_WARN_THROTTLE(logger_, *clock_, 1000,
+      "IMU buffer: non-finite values, ignoring");
+    return;
+  }
+
+  Eigen::Vector3d accel(a.x, a.y, a.z);
+  if (msg->orientation_covariance[0] >= 0.0) {
+    const auto & q = msg->orientation;
+    Eigen::Quaterniond ori(q.w, q.x, q.y, q.z);
+    if (ori.squaredNorm() > 0.5) {
+      ori.normalize();
+      constexpr double kGravity = 9.80665;
+      Eigen::Vector3d g_imu =
+        ori.toRotationMatrix().transpose() * Eigen::Vector3d(0.0, 0.0, kGravity);
+      accel -= g_imu;
+    } else {
+      accel.setZero();
+      RCLCPP_WARN_THROTTLE(logger_, *clock_, 5000,
+        "IMU buffer: degenerate orientation quaternion, translation deskew disabled");
+    }
+  } else {
+    accel.setZero();
+    RCLCPP_WARN_ONCE(logger_,
+      "IMU buffer: IMU has no orientation — cannot subtract gravity, "
+      "translation deskew disabled (rotation-only)");
+  }
+
+  ImuSample sample;
+  sample.wx = w.x;  sample.wy = w.y;  sample.wz = w.z;
+  sample.ax = accel.x();  sample.ay = accel.y();  sample.az = accel.z();
+  sample.stamp = rclcpp::Time(msg->header.stamp);
+
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    buffer_.push_back(sample);
+    while (static_cast<int>(buffer_.size()) > max_size_)
+      buffer_.pop_front();
+  }
+
+  auto avg = std::make_shared<AveragedImu>();
+  avg->angular_vel = Eigen::Vector3d(w.x, w.y, w.z);
+  avg->linear_accel = accel;
+  avg->valid = true;
+  avg->frame_id = msg->header.frame_id;
+  std::atomic_store(&snapshot_, std::const_pointer_cast<const AveragedImu>(avg));
+}
+
+}  // namespace polka

--- a/src/merge_engine/cuda_merge_engine.cu
+++ b/src/merge_engine/cuda_merge_engine.cu
@@ -20,6 +20,25 @@
 #include <cstring>
 #include <algorithm>
 #include <cmath>
+#include <stdexcept>
+
+#define POLKA_CUDA_CHECK(call)                                          \
+  do {                                                                  \
+    cudaError_t err = (call);                                           \
+    if (err != cudaSuccess) {                                           \
+      fprintf(stderr, "[polka] CUDA error at %s:%d: %s\n",             \
+              __FILE__, __LINE__, cudaGetErrorString(err));             \
+    }                                                                   \
+  } while (0)
+
+#define POLKA_CUDA_CHECK_KERNEL()                                       \
+  do {                                                                  \
+    cudaError_t err = cudaGetLastError();                               \
+    if (err != cudaSuccess) {                                           \
+      fprintf(stderr, "[polka] CUDA kernel launch error at %s:%d: %s\n", \
+              __FILE__, __LINE__, cudaGetErrorString(err));             \
+    }                                                                   \
+  } while (0)
 
 namespace polka {
 
@@ -376,19 +395,19 @@ CudaMergeEngine::CudaMergeEngine(const MergeConfig & config)
 {
   impl_->max_total_points = impl_->max_points_per_source * config.sources.size();
 
-  cudaMalloc(&impl_->d_buf_a, impl_->max_total_points * sizeof(float4));
-  cudaMalloc(&impl_->d_buf_b, impl_->max_total_points * sizeof(float4));
-  cudaMalloc(&impl_->d_count_a, sizeof(int));
-  cudaMalloc(&impl_->d_count_b, sizeof(int));
-  cudaMalloc(&impl_->d_tf, 16 * sizeof(float));
+  POLKA_CUDA_CHECK(cudaMalloc(&impl_->d_buf_a, impl_->max_total_points * sizeof(float4)));
+  POLKA_CUDA_CHECK(cudaMalloc(&impl_->d_buf_b, impl_->max_total_points * sizeof(float4)));
+  POLKA_CUDA_CHECK(cudaMalloc(&impl_->d_count_a, sizeof(int)));
+  POLKA_CUDA_CHECK(cudaMalloc(&impl_->d_count_b, sizeof(int)));
+  POLKA_CUDA_CHECK(cudaMalloc(&impl_->d_tf, 16 * sizeof(float)));
 
-  cudaMalloc(&impl_->d_voxel_keys, POLKA_VOXEL_TABLE_SIZE * sizeof(int));
-  cudaMalloc(&impl_->d_voxel_points, POLKA_VOXEL_TABLE_SIZE * sizeof(float4));
+  POLKA_CUDA_CHECK(cudaMalloc(&impl_->d_voxel_keys, POLKA_VOXEL_TABLE_SIZE * sizeof(int)));
+  POLKA_CUDA_CHECK(cudaMalloc(&impl_->d_voxel_points, POLKA_VOXEL_TABLE_SIZE * sizeof(float4)));
 
-  cudaMalloc(&impl_->d_scan_ranges_int, POLKA_MAX_SCAN_BINS * sizeof(int));
-  cudaMalloc(&impl_->d_scan_ranges_float, POLKA_MAX_SCAN_BINS * sizeof(float));
+  POLKA_CUDA_CHECK(cudaMalloc(&impl_->d_scan_ranges_int, POLKA_MAX_SCAN_BINS * sizeof(int)));
+  POLKA_CUDA_CHECK(cudaMalloc(&impl_->d_scan_ranges_float, POLKA_MAX_SCAN_BINS * sizeof(float)));
 
-  cudaStreamCreate(&impl_->stream);
+  POLKA_CUDA_CHECK(cudaStreamCreate(&impl_->stream));
 }
 
 CudaMergeEngine::~CudaMergeEngine()
@@ -409,7 +428,7 @@ CudaMergeEngine::~CudaMergeEngine()
 CloudT::Ptr CudaMergeEngine::merge(const std::vector<MergeInput> & sources)
 {
   auto & s = impl_->stream;
-  cudaMemsetAsync(impl_->d_count_b, 0, sizeof(int), s);
+  POLKA_CUDA_CHECK(cudaMemsetAsync(impl_->d_count_b, 0, sizeof(int), s));
 
   size_t input_offset = 0;
   for (const auto & src : sources) {
@@ -424,34 +443,35 @@ CloudT::Ptr CudaMergeEngine::merge(const std::vector<MergeInput> & sources)
       const auto & pt = src.cloud->points[i];
       packed[i] = make_float4(pt.x, pt.y, pt.z, pt.intensity);
     }
-    cudaMemcpyAsync(impl_->d_buf_a + input_offset, packed.data(),
-      n * sizeof(float4), cudaMemcpyHostToDevice, s);
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->d_buf_a + input_offset, packed.data(),
+      n * sizeof(float4), cudaMemcpyHostToDevice, s));
 
     Eigen::Matrix4f mat = src.transform.cast<float>().matrix();
     float tf[16];
     for (int r = 0; r < 4; ++r)
       for (int c = 0; c < 4; ++c)
         tf[r * 4 + c] = mat(r, c);
-    cudaMemcpyAsync(impl_->d_tf, tf, 16 * sizeof(float), cudaMemcpyHostToDevice, s);
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->d_tf, tf, 16 * sizeof(float), cudaMemcpyHostToDevice, s));
 
     GpuFilterParams gf = impl_->to_gpu_filter(src.filter_params);
     int blocks = (static_cast<int>(n) + 255) / 256;
     fused_transform_filter_kernel<<<blocks, 256, 0, s>>>(
       impl_->d_buf_a + input_offset, impl_->d_buf_b, impl_->d_count_b,
       impl_->d_tf, gf, static_cast<int>(n));
+    POLKA_CUDA_CHECK_KERNEL();
 
     input_offset += n;
   }
 
   int count = 0;
-  cudaMemcpyAsync(&count, impl_->d_count_b, sizeof(int), cudaMemcpyDeviceToHost, s);
-  cudaStreamSynchronize(s);
+  POLKA_CUDA_CHECK(cudaMemcpyAsync(&count, impl_->d_count_b, sizeof(int), cudaMemcpyDeviceToHost, s));
+  POLKA_CUDA_CHECK(cudaStreamSynchronize(s));
 
   auto output = std::make_shared<CloudT>();
   if (count > 0) {
     output->resize(count);
     std::vector<float4> packed_out(count);
-    cudaMemcpy(packed_out.data(), impl_->d_buf_b, count * sizeof(float4), cudaMemcpyDeviceToHost);
+    POLKA_CUDA_CHECK(cudaMemcpy(packed_out.data(), impl_->d_buf_b, count * sizeof(float4), cudaMemcpyDeviceToHost));
     for (int i = 0; i < count; ++i) {
       auto & pt = output->points[i];
       pt.x = packed_out[i].x;
@@ -472,7 +492,7 @@ PipelineResult CudaMergeEngine::merge_pipeline(
 {
   auto & s = impl_->stream;
 
-  cudaMemsetAsync(impl_->d_count_b, 0, sizeof(int), s);
+  POLKA_CUDA_CHECK(cudaMemsetAsync(impl_->d_count_b, 0, sizeof(int), s));
 
   size_t input_offset = 0;
   for (const auto & src : sources) {
@@ -487,28 +507,29 @@ PipelineResult CudaMergeEngine::merge_pipeline(
       const auto & pt = src.cloud->points[i];
       packed[i] = make_float4(pt.x, pt.y, pt.z, pt.intensity);
     }
-    cudaMemcpyAsync(impl_->d_buf_a + input_offset, packed.data(),
-      n * sizeof(float4), cudaMemcpyHostToDevice, s);
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->d_buf_a + input_offset, packed.data(),
+      n * sizeof(float4), cudaMemcpyHostToDevice, s));
 
     Eigen::Matrix4f mat = src.transform.cast<float>().matrix();
     float tf[16];
     for (int r = 0; r < 4; ++r)
       for (int c = 0; c < 4; ++c)
         tf[r * 4 + c] = mat(r, c);
-    cudaMemcpyAsync(impl_->d_tf, tf, 16 * sizeof(float), cudaMemcpyHostToDevice, s);
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->d_tf, tf, 16 * sizeof(float), cudaMemcpyHostToDevice, s));
 
     GpuFilterParams gf = impl_->to_gpu_filter(src.filter_params);
     int blocks = (static_cast<int>(n) + 255) / 256;
     fused_transform_filter_kernel<<<blocks, 256, 0, s>>>(
       impl_->d_buf_a + input_offset, impl_->d_buf_b, impl_->d_count_b,
       impl_->d_tf, gf, static_cast<int>(n));
+    POLKA_CUDA_CHECK_KERNEL();
 
     input_offset += n;
   }
 
   int merge_count = 0;
-  cudaMemcpyAsync(&merge_count, impl_->d_count_b, sizeof(int), cudaMemcpyDeviceToHost, s);
-  cudaStreamSynchronize(s);
+  POLKA_CUDA_CHECK(cudaMemcpyAsync(&merge_count, impl_->d_count_b, sizeof(int), cudaMemcpyDeviceToHost, s));
+  POLKA_CUDA_CHECK(cudaStreamSynchronize(s));
 
   if (merge_count <= 0) return {std::make_shared<CloudT>(), {}};
 
@@ -520,21 +541,22 @@ PipelineResult CudaMergeEngine::merge_pipeline(
     ofp.box_enabled || ofp.n_self_boxes > 0 || ofp.height_cap_enabled;
 
   if (any_output_filter) {
-    cudaMemsetAsync(impl_->d_count_a, 0, sizeof(int), s);
+    POLKA_CUDA_CHECK(cudaMemsetAsync(impl_->d_count_a, 0, sizeof(int), s));
     int blocks = (cur_count + 255) / 256;
     output_filter_kernel<<<blocks, 256, 0, s>>>(
       impl_->d_buf_b, impl_->d_buf_a, impl_->d_count_a, ofp, cur_count);
+    POLKA_CUDA_CHECK_KERNEL();
 
-    cudaMemcpyAsync(&cur_count, impl_->d_count_a, sizeof(int), cudaMemcpyDeviceToHost, s);
-    cudaStreamSynchronize(s);
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(&cur_count, impl_->d_count_a, sizeof(int), cudaMemcpyDeviceToHost, s));
+    POLKA_CUDA_CHECK(cudaStreamSynchronize(s));
 
     cur_data = impl_->d_buf_a;
     if (cur_count <= 0) return {std::make_shared<CloudT>(), {}};
   }
 
   if (config.voxel.enabled && config.voxel.leaf_x > 0.0f) {
-    cudaMemsetAsync(impl_->d_voxel_keys, 0,
-      POLKA_VOXEL_TABLE_SIZE * sizeof(int), s);
+    POLKA_CUDA_CHECK(cudaMemsetAsync(impl_->d_voxel_keys, 0,
+      POLKA_VOXEL_TABLE_SIZE * sizeof(int), s));
 
     float inv_lx = 1.0f / config.voxel.leaf_x;
     float inv_ly = 1.0f / config.voxel.leaf_y;
@@ -544,18 +566,20 @@ PipelineResult CudaMergeEngine::merge_pipeline(
     voxel_insert_kernel<<<blocks, 256, 0, s>>>(
       cur_data, impl_->d_voxel_keys, impl_->d_voxel_points,
       inv_lx, inv_ly, inv_lz, cur_count);
+    POLKA_CUDA_CHECK_KERNEL();
 
     float4 * voxel_out = (cur_data == impl_->d_buf_a) ? impl_->d_buf_b : impl_->d_buf_a;
     int * voxel_cnt = (cur_data == impl_->d_buf_a) ? impl_->d_count_b : impl_->d_count_a;
 
-    cudaMemsetAsync(voxel_cnt, 0, sizeof(int), s);
+    POLKA_CUDA_CHECK(cudaMemsetAsync(voxel_cnt, 0, sizeof(int), s));
     int compact_blocks = (POLKA_VOXEL_TABLE_SIZE + 255) / 256;
     voxel_compact_kernel<<<compact_blocks, 256, 0, s>>>(
       impl_->d_voxel_keys, impl_->d_voxel_points,
       voxel_out, voxel_cnt);
+    POLKA_CUDA_CHECK_KERNEL();
 
-    cudaMemcpyAsync(&cur_count, voxel_cnt, sizeof(int), cudaMemcpyDeviceToHost, s);
-    cudaStreamSynchronize(s);
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(&cur_count, voxel_cnt, sizeof(int), cudaMemcpyDeviceToHost, s));
+    POLKA_CUDA_CHECK(cudaStreamSynchronize(s));
 
     cur_data = voxel_out;
     if (cur_count <= 0) return {std::make_shared<CloudT>(), {}};
@@ -570,16 +594,18 @@ PipelineResult CudaMergeEngine::merge_pipeline(
     int r_max_int;
     std::memcpy(&r_max_int, &gfp.r_max, sizeof(int));
     std::vector<int> init_vals(n_bins, r_max_int);
-    cudaMemcpyAsync(impl_->d_scan_ranges_int, init_vals.data(),
-      n_bins * sizeof(int), cudaMemcpyHostToDevice, s);
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->d_scan_ranges_int, init_vals.data(),
+      n_bins * sizeof(int), cudaMemcpyHostToDevice, s));
 
     int blocks = (cur_count + 255) / 256;
     flatten_kernel<<<blocks, 256, 0, s>>>(
       cur_data, impl_->d_scan_ranges_int, gfp, cur_count);
+    POLKA_CUDA_CHECK_KERNEL();
 
     int decode_blocks = (n_bins + 255) / 256;
     scan_decode_kernel<<<decode_blocks, 256, 0, s>>>(
       impl_->d_scan_ranges_int, impl_->d_scan_ranges_float, gfp.r_max, n_bins);
+    POLKA_CUDA_CHECK_KERNEL();
 
     scan_ranges.resize(n_bins);
   }
@@ -588,16 +614,16 @@ PipelineResult CudaMergeEngine::merge_pipeline(
   std::vector<float4> packed_out;
   if (cur_count > 0) {
     packed_out.resize(cur_count);
-    cudaMemcpyAsync(packed_out.data(), cur_data,
-      cur_count * sizeof(float4), cudaMemcpyDeviceToHost, s);
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(packed_out.data(), cur_data,
+      cur_count * sizeof(float4), cudaMemcpyDeviceToHost, s));
   }
 
   if (config.scan_enabled && !scan_ranges.empty()) {
-    cudaMemcpyAsync(scan_ranges.data(), impl_->d_scan_ranges_float,
-      scan_ranges.size() * sizeof(float), cudaMemcpyDeviceToHost, s);
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(scan_ranges.data(), impl_->d_scan_ranges_float,
+      scan_ranges.size() * sizeof(float), cudaMemcpyDeviceToHost, s));
   }
 
-  cudaStreamSynchronize(s);
+  POLKA_CUDA_CHECK(cudaStreamSynchronize(s));
 
   if (cur_count > 0) {
     output->resize(cur_count);

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -54,8 +54,10 @@ rclcpp::QoS build_qos(const OutputQosConfig & cfg)
   else
     qos.durability(rclcpp::DurabilityPolicy::Volatile);
 
-  if (cfg.liveliness == "manual_by_topic" || cfg.liveliness == "manual_by_node")
+  if (cfg.liveliness == "manual_by_topic")
     qos.liveliness(rclcpp::LivelinessPolicy::ManualByTopic);
+  else if (cfg.liveliness == "manual_by_node")
+    qos.liveliness(rclcpp::LivelinessPolicy::ManualByNode);
   else
     qos.liveliness(rclcpp::LivelinessPolicy::Automatic);
 
@@ -101,32 +103,33 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
     merge_engine_->is_gpu() ? "GPU (full pipeline)" : "CPU",
     merge_engine_->is_gpu() ? "" : " (set enable_gpu:=true for GPU acceleration)");
 
-  if (config_.motion_compensation.enabled)
-    setup_imu_subscriber();
+  if (config_.motion_compensation.enabled && !config_.motion_compensation.imu_topic.empty())
+    global_imu_ = std::make_shared<ImuBuffer>(
+      this, config_.motion_compensation.imu_topic,
+      config_.motion_compensation.imu_buffer_size);
+  else if (config_.motion_compensation.enabled)
+    RCLCPP_WARN(get_logger(),
+      "motion compensation enabled but imu_topic is empty, deskewing will not activate");
 
-  imu_frame_id_ = config_.motion_compensation.imu_frame;
-
-  // IMU getter for source adapters (per-point deskewing)
+  // Global IMU getter for source adapters that don't have a per-source IMU
   SourceAdapter::ImuGetter imu_getter = nullptr;
-  if (config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew) {
+  if (config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew
+      && global_imu_) {
     imu_getter = [this]() -> std::shared_ptr<const AveragedImu> {
-      return std::atomic_load(&imu_snapshot_);
+      return global_imu_->snapshot();
     };
   }
 
   bool gpu_filters = merge_engine_->is_gpu();
+  bool deskew = config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew;
   for (const auto & src_cfg : config_.sources)
     sources_.push_back(std::make_unique<SourceAdapter>(
-      this, src_cfg, gpu_filters, imu_getter,
-      config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew,
+      this, src_cfg, gpu_filters, imu_getter, deskew,
       config_.motion_compensation.deskew_timestamp_field,
-      config_.motion_compensation.enabled ? tf_buffer_ : nullptr,
-      imu_frame_id_));
+      tf_buffer_, config_.motion_compensation.imu_buffer_size));
 
   last_good_transforms_.resize(sources_.size(), Eigen::Isometry3d::Identity());
   tf_fail_counts_.resize(sources_.size(), 0);
-  imu_to_source_rotations_.resize(sources_.size(), Eigen::Matrix3d::Identity());
-  imu_to_source_cached_.resize(sources_.size(), false);
 
   build_output_filters();
 
@@ -184,8 +187,6 @@ void PolkaNode::output_callback()
     Eigen::Isometry3d transform;
     FilterParams filter_params;
     rclcpp::Time stamp;
-    std::string frame_id;
-    size_t source_index;
   };
   std::vector<SourceData> source_data;
 
@@ -216,8 +217,7 @@ void PolkaNode::output_callback()
       transform = last_good_transforms_[i];
     }
 
-    source_data.push_back({cloud, transform, src->filter_params(), src->last_stamp(),
-                           src->frame_id(), i});
+    source_data.push_back({cloud, transform, src->filter_params(), src->last_stamp()});
   }
 
   bool has_fresh_data = !source_data.empty();
@@ -261,8 +261,8 @@ void PolkaNode::output_callback()
   // Pass 2: Apply IMU-based inter-source compensation and build MergeInputs
   bool do_compensate = false;
   AveragedImu imu_for_alignment;
-  if (config_.motion_compensation.enabled) {
-    auto imu = std::atomic_load(&imu_snapshot_);
+  if (config_.motion_compensation.enabled && global_imu_) {
+    auto imu = global_imu_->snapshot();
     if (imu && imu->valid) {
       imu_for_alignment = *imu;
       do_compensate = true;
@@ -276,33 +276,8 @@ void PolkaNode::output_callback()
     if (do_compensate) {
       double dt = (sd.stamp - output_stamp).seconds();
       if (std::abs(dt) > 1e-6) {
-        Eigen::Vector3d w = imu_for_alignment.angular_vel;
-        Eigen::Vector3d a = imu_for_alignment.linear_accel;
-
-        if (!imu_to_source_cached_[sd.source_index] && !imu_frame_id_.empty()) {
-          if (imu_frame_id_ == sd.frame_id) {
-            imu_to_source_cached_[sd.source_index] = true;
-          } else {
-            try {
-              auto tf_msg = tf_buffer_->lookupTransform(
-                sd.frame_id, imu_frame_id_, tf2::TimePointZero);
-              imu_to_source_rotations_[sd.source_index] =
-                tf2::transformToEigen(tf_msg.transform).rotation();
-              imu_to_source_cached_[sd.source_index] = true;
-            } catch (const tf2::TransformException & ex) {
-              RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000,
-                "IMU('%s') -> source('%s') TF not yet available: %s",
-                imu_frame_id_.c_str(), sd.frame_id.c_str(), ex.what());
-            }
-          }
-        }
-
-        if (imu_to_source_cached_[sd.source_index]) {
-          w = imu_to_source_rotations_[sd.source_index] * w;
-          a = imu_to_source_rotations_[sd.source_index] * a;
-        }
-
-        Eigen::Isometry3d delta = compute_motion_delta(w, a, dt);
+        Eigen::Isometry3d delta = compute_motion_delta(
+          imu_for_alignment.angular_vel, imu_for_alignment.linear_accel, dt);
         final_transform = delta * sd.transform;
       }
     }
@@ -417,83 +392,6 @@ void PolkaNode::publish_scan(CloudT::ConstPtr cloud, const rclcpp::Time & stamp)
   scan_pub_->publish(scan);
 }
 
-void PolkaNode::setup_imu_subscriber()
-{
-  const auto & mc = config_.motion_compensation;
-  if (mc.imu_topic.empty()) {
-    RCLCPP_WARN(get_logger(),
-      "motion compensation enabled but imu_topic is empty, deskewing will not activate");
-    return;
-  }
-
-  imu_sub_ = create_subscription<sensor_msgs::msg::Imu>(
-    mc.imu_topic, rclcpp::SensorDataQoS(),
-    std::bind(&PolkaNode::imu_callback, this, std::placeholders::_1));
-  RCLCPP_INFO(get_logger(), "motion compensation: subscribing to IMU on '%s'",
-    mc.imu_topic.c_str());
-}
-
-void PolkaNode::imu_callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
-{
-  if (imu_frame_id_.empty() && !msg->header.frame_id.empty()) {
-    imu_frame_id_ = msg->header.frame_id;
-    RCLCPP_INFO(get_logger(), "motion compensation: auto-detected IMU frame '%s'",
-      imu_frame_id_.c_str());
-    for (auto & src : sources_)
-      src->set_imu_frame_id(imu_frame_id_);
-  }
-
-  const auto & a = msg->linear_acceleration;
-  const auto & w = msg->angular_velocity;
-  if (!std::isfinite(a.x) || !std::isfinite(a.y) || !std::isfinite(a.z) ||
-      !std::isfinite(w.x) || !std::isfinite(w.y) || !std::isfinite(w.z)) {
-    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000,
-      "motion compensation: non-finite values in IMU, ignoring");
-    return;
-  }
-
-  Eigen::Vector3d accel(a.x, a.y, a.z);
-  if (msg->orientation_covariance[0] >= 0.0) {
-    const auto & q = msg->orientation;
-    Eigen::Quaterniond ori(q.w, q.x, q.y, q.z);
-    if (ori.squaredNorm() > 0.5) {
-      ori.normalize();
-      constexpr double kGravity = 9.80665;
-      Eigen::Vector3d g_imu =
-        ori.toRotationMatrix().transpose() * Eigen::Vector3d(0.0, 0.0, kGravity);
-      accel -= g_imu;
-    } else {
-      accel.setZero();
-      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000,
-        "motion compensation: degenerate IMU orientation quaternion, "
-        "translation deskew disabled");
-    }
-  } else {
-    accel.setZero();
-    RCLCPP_WARN_ONCE(get_logger(),
-      "motion compensation: IMU has no orientation — "
-      "cannot subtract gravity, translation deskew disabled (rotation-only)");
-  }
-
-  ImuSample sample;
-  sample.wx = w.x;  sample.wy = w.y;  sample.wz = w.z;
-  sample.ax = accel.x();  sample.ay = accel.y();  sample.az = accel.z();
-  sample.stamp = rclcpp::Time(msg->header.stamp);
-
-  {
-    std::lock_guard<std::mutex> lock(imu_mutex_);
-    imu_buffer_.push_back(sample);
-    while (static_cast<int>(imu_buffer_.size()) > config_.motion_compensation.imu_buffer_size)
-      imu_buffer_.pop_front();
-  }
-
-  auto avg = std::make_shared<AveragedImu>();
-  avg->angular_vel = Eigen::Vector3d(w.x, w.y, w.z);
-  avg->linear_accel = accel;
-  avg->valid = true;
-  std::atomic_store(&imu_snapshot_, std::const_pointer_cast<const AveragedImu>(avg));
-}
-
 PipelineConfig PolkaNode::build_pipeline_config() const
 {
   PipelineConfig pcfg;
@@ -593,13 +491,16 @@ bool PolkaNode::reconfigure()
   else if (!config_.scan_output.enabled && prev_scan_enabled)
     scan_pub_.reset();
 
-  // Toggle IMU subscriber
-  bool imu_was_enabled = (imu_sub_ != nullptr);
-  bool imu_now_enabled = config_.motion_compensation.enabled;
+  // Toggle global IMU buffer
+  bool imu_was_enabled = (global_imu_ != nullptr);
+  bool imu_now_enabled = config_.motion_compensation.enabled
+                         && !config_.motion_compensation.imu_topic.empty();
   if (imu_now_enabled && !imu_was_enabled) {
-    setup_imu_subscriber();
+    global_imu_ = std::make_shared<ImuBuffer>(
+      this, config_.motion_compensation.imu_topic,
+      config_.motion_compensation.imu_buffer_size);
   } else if (!imu_now_enabled && imu_was_enabled) {
-    imu_sub_.reset();
+    global_imu_.reset();
     RCLCPP_INFO(get_logger(), "motion compensation disabled");
   }
 

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -224,19 +224,18 @@ void PolkaNode::output_callback()
   if (!has_fresh_data) {
     std::lock_guard<std::mutex> lock(last_data_mutex_);
     if (last_cloud_ && !last_cloud_->empty()) {
-      rclcpp::Time stale_stamp = now;
       if (cloud_pub_) {
         sensor_msgs::msg::PointCloud2 msg;
         pcl::toROSMsg(*last_cloud_, msg);
         msg.header.frame_id = config_.output_frame_id;
-        msg.header.stamp = stale_stamp;
+        msg.header.stamp = last_cloud_stamp_;
         cloud_pub_->publish(msg);
       }
       if (scan_pub_) {
         if (!last_scan_ranges_.empty())
-          publish_scan_from_ranges(last_scan_ranges_, stale_stamp);
+          publish_scan_from_ranges(last_scan_ranges_, last_cloud_stamp_);
         else
-          publish_scan(last_cloud_, stale_stamp);
+          publish_scan(last_cloud_, last_cloud_stamp_);
       }
       return;
     } else {
@@ -493,44 +492,6 @@ void PolkaNode::imu_callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
   avg->linear_accel = accel;
   avg->valid = true;
   std::atomic_store(&imu_snapshot_, std::const_pointer_cast<const AveragedImu>(avg));
-}
-
-AveragedImu PolkaNode::average_imu(
-  const rclcpp::Time & start, const rclcpp::Time & end) const
-{
-  AveragedImu result;
-  std::lock_guard<std::mutex> lock(imu_mutex_);
-
-  if (imu_buffer_.empty()) return result;
-
-  Eigen::Vector3d sum_w = Eigen::Vector3d::Zero();
-  Eigen::Vector3d sum_a = Eigen::Vector3d::Zero();
-  int count = 0;
-
-  for (const auto & s : imu_buffer_) {
-    if (s.stamp >= start && s.stamp <= end) {
-      sum_w += Eigen::Vector3d(s.wx, s.wy, s.wz);
-      sum_a += Eigen::Vector3d(s.ax, s.ay, s.az);
-      ++count;
-    }
-  }
-
-  if (count > 0) {
-    result.angular_vel = sum_w / count;
-    result.linear_accel = sum_a / count;
-    result.valid = true;
-  } else if (!imu_buffer_.empty()) {
-    // No samples in range — use the most recent sample
-    double age = (this->now() - imu_buffer_.back().stamp).seconds();
-    if (age <= config_.motion_compensation.max_imu_age) {
-      const auto & s = imu_buffer_.back();
-      result.angular_vel = Eigen::Vector3d(s.wx, s.wy, s.wz);
-      result.linear_accel = Eigen::Vector3d(s.ax, s.ay, s.az);
-      result.valid = true;
-    }
-  }
-
-  return result;
 }
 
 PipelineConfig PolkaNode::build_pipeline_config() const

--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "polka/source_adapter.hpp"
-#include "polka/polka_node.hpp"  // for AveragedImu definition
 #include "polka/se3_exp.hpp"
 #include "polka/filters/range_filter.hpp"
 #include "polka/filters/angular_filter.hpp"
@@ -31,12 +30,20 @@ SourceAdapter::SourceAdapter(rclcpp::Node * node, const SourceConfig & config, b
                              ImuGetter imu_getter, bool deskew_enabled,
                              const std::string & timestamp_field_hint,
                              std::shared_ptr<tf2_ros::Buffer> tf_buffer,
-                             const std::string & imu_frame_id)
+                             int imu_buffer_size)
 : node_(node), config_(config), logger_(node->get_logger()), gpu_filters_(gpu_filters),
   get_imu_(std::move(imu_getter)), deskew_enabled_(deskew_enabled),
-  timestamp_field_hint_(timestamp_field_hint),
-  tf_buffer_(std::move(tf_buffer)), imu_frame_id_(imu_frame_id)
+  timestamp_field_hint_(timestamp_field_hint), tf_buffer_(std::move(tf_buffer))
 {
+  // Per-source IMU: if configured, create a local buffer and override the getter
+  if (deskew_enabled_ && !config.imu_topic.empty()) {
+    local_imu_ = std::make_shared<ImuBuffer>(node, config.imu_topic, imu_buffer_size);
+    get_imu_ = [this]() -> std::shared_ptr<const AveragedImu> {
+      return local_imu_->snapshot();
+    };
+    RCLCPP_INFO(logger_, "polka: source '%s' using per-source IMU on '%s'",
+      config.name.c_str(), config.imu_topic.c_str());
+  }
   // Build QoS
   rclcpp::QoS qos(config.qos_history_depth);
   if (config.qos_reliability == "best_effort") {
@@ -154,15 +161,24 @@ void SourceAdapter::deskew_cloud(
   size_t n = cloud.size();
   if (n == 0 || n != static_cast<size_t>(raw_msg.width) * raw_msg.height) return;
 
-  cache_imu_rotation();
-
-  Eigen::Vector3d angular_vel = imu.angular_vel;
-  Eigen::Vector3d accel = imu.linear_accel;
-  if (imu_rotation_cached_) {
-    angular_vel = R_imu_to_sensor_ * angular_vel;
-    accel = R_imu_to_sensor_ * accel;
+  // Rotate IMU data from IMU frame into sensor frame (identity if same frame or TF unavailable)
+  Eigen::Matrix3d R_imu_to_sensor = Eigen::Matrix3d::Identity();
+  if (tf_buffer_ && !imu.frame_id.empty()) {
+    std::string sensor_frame;
+    { std::lock_guard<std::mutex> lock(meta_mutex_); sensor_frame = frame_id_; }
+    if (!sensor_frame.empty() && sensor_frame != imu.frame_id) {
+      try {
+        auto tf_msg = tf_buffer_->lookupTransform(
+          sensor_frame, imu.frame_id, tf2::TimePointZero);
+        R_imu_to_sensor = tf2::transformToEigen(tf_msg.transform).rotation();
+      } catch (const tf2::TransformException &) {
+        // Identity fallback — same behavior as before TF rotation was added
+      }
+    }
   }
 
+  const Eigen::Vector3d angular_vel = R_imu_to_sensor * imu.angular_vel;
+  const Eigen::Vector3d accel = R_imu_to_sensor * imu.linear_accel;
   const double header_sec = rclcpp::Time(raw_msg.header.stamp).seconds();
 
   const uint8_t * raw_data = raw_msg.data.data();
@@ -277,40 +293,6 @@ rclcpp::Time SourceAdapter::last_stamp() const
 {
   std::lock_guard<std::mutex> lock(meta_mutex_);
   return last_received_time_;
-}
-
-void SourceAdapter::set_imu_frame_id(const std::string & frame_id)
-{
-  if (imu_frame_id_.empty() && !frame_id.empty()) {
-    imu_frame_id_ = frame_id;
-    imu_rotation_cached_ = false;
-  }
-}
-
-void SourceAdapter::cache_imu_rotation()
-{
-  if (imu_rotation_cached_ || imu_frame_id_.empty() || frame_id_.empty() || !tf_buffer_)
-    return;
-
-  if (imu_frame_id_ == frame_id_) {
-    R_imu_to_sensor_ = Eigen::Matrix3d::Identity();
-    imu_rotation_cached_ = true;
-    RCLCPP_INFO(logger_, "polka: source '%s' IMU frame == sensor frame ('%s'), no rotation needed",
-      config_.name.c_str(), frame_id_.c_str());
-    return;
-  }
-
-  try {
-    auto tf_msg = tf_buffer_->lookupTransform(frame_id_, imu_frame_id_, tf2::TimePointZero);
-    R_imu_to_sensor_ = tf2::transformToEigen(tf_msg.transform).rotation();
-    imu_rotation_cached_ = true;
-    RCLCPP_INFO(logger_, "polka: source '%s' cached IMU('%s') -> sensor('%s') rotation",
-      config_.name.c_str(), imu_frame_id_.c_str(), frame_id_.c_str());
-  } catch (const tf2::TransformException & ex) {
-    RCLCPP_WARN_THROTTLE(logger_, *node_->get_clock(), 5000,
-      "polka: source '%s' IMU('%s') -> sensor('%s') TF not yet available: %s",
-      config_.name.c_str(), imu_frame_id_.c_str(), frame_id_.c_str(), ex.what());
-  }
 }
 
 void SourceAdapter::rebuild_filters(const FilterParams & fp)

--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -194,9 +194,12 @@ void SourceAdapter::apply_filters(CloudT & cloud)
 
 void SourceAdapter::store_cloud(CloudT::Ptr cloud, const std_msgs::msg::Header & header)
 {
-  frame_id_ = header.frame_id;
+  {
+    std::lock_guard<std::mutex> lock(meta_mutex_);
+    frame_id_ = header.frame_id;
+    last_received_time_ = rclcpp::Time(header.stamp);
+  }
   std::atomic_store(&buffer_, std::static_pointer_cast<CloudT>(cloud));
-  last_received_time_ = rclcpp::Time(header.stamp);
   has_received_.store(true);
   message_counter_.fetch_add(1);
 }
@@ -257,14 +260,22 @@ CloudT::ConstPtr SourceAdapter::get_latest() const
   return std::atomic_load(&buffer_);
 }
 
+std::string SourceAdapter::frame_id() const
+{
+  std::lock_guard<std::mutex> lock(meta_mutex_);
+  return frame_id_;
+}
+
 bool SourceAdapter::is_stale(double timeout_sec, const rclcpp::Time & now) const
 {
   if (!has_received_.load()) return true;
+  std::lock_guard<std::mutex> lock(meta_mutex_);
   return (now - last_received_time_).seconds() > timeout_sec;
 }
 
 rclcpp::Time SourceAdapter::last_stamp() const
 {
+  std::lock_guard<std::mutex> lock(meta_mutex_);
   return last_received_time_;
 }
 


### PR DESCRIPTION
## Summary
- Fix data race on `last_received_time_` and `frame_id_` in SourceAdapter by adding mutex protection
- Fix stale data republishing with fabricated `now` timestamp — use original `last_cloud_stamp_` instead
- Remove unused `average_imu()` dead code
- Refactor `ConfigLoader::load()`/`reload()` to eliminate ~60 lines of duplication via `read_common_params()`
- Add `POLKA_CUDA_CHECK` / `POLKA_CUDA_CHECK_KERNEL` macros for CUDA error checking on all kernel launches and memory operations

## Test plan
- [ ] Verify build passes on Jazzy (`colcon build --packages-select polka`)
- [ ] Run with multiple LiDAR sources and confirm merged cloud output is correct
- [ ] Enable motion compensation and verify deskewing still works
- [ ] Test runtime reconfiguration via `ros2 param set`
- [ ] If GPU available, verify CUDA path produces same output as CPU path