### PR TITLE
Warn once per source on missing 'intensity' field

### DIFF
--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -97,6 +97,11 @@ bool SourceAdapter::validate_fields(const sensor_msgs::msg::PointCloud2 & msg)
     return false;
   }
   missing_intensity_ = !has_intensity;
+  if (missing_intensity_) {
+    RCLCPP_WARN(logger_,
+      "polka: source '%s' missing 'intensity' field - publishing with intensity=0",
+      config_.name.c_str());
+  }
   return true;
 }
 
@@ -228,12 +233,6 @@ void SourceAdapter::pc2_callback(sensor_msgs::msg::PointCloud2::ConstSharedPtr m
     fields_valid_ = validate_fields(*msg);
   }
   if (!fields_valid_) return;
-
-  if (missing_intensity_) {
-    RCLCPP_WARN_THROTTLE(logger_, *node_->get_clock(), 10000,
-      "polka: source '%s' missing 'intensity' field - publishing with intensity=0",
-      config_.name.c_str());
-  }
 
   // Detect per-point timestamp field on first message
   if (!timestamp_field_detected_)


### PR DESCRIPTION
## Summary
- Move the missing-intensity warning into `validate_fields`, which runs exactly once per source (gated by `fields_validated_`).
- Drop the throttled per-message check in `pc2_callback` — a topic's field schema doesn't change at runtime, so a 10 s repeat just clutters the journal.
- Net diff: 5 inserted, 6 deleted in one file.

Closes #18

## Test plan
- [ ] `colcon build --packages-select polka` clean on humble.
- [ ] Replay a bag with a source missing intensity → exactly one WARN line per such source over the run.
- [ ] Replay a bag with a source that has intensity → zero intensity warnings.
- [ ] Two sources, one missing intensity → one warning, naming the offending source.

Jazzy PR will follow as a sibling.