### PR TITLE
docs: add pipeline_demo GIF to README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 <p align="center">
   <img src="images/polka.png" alt="Polka" width="700"/>
+  <img width="700" alt="pipeline_demo" src="https://github.com/user-attachments/assets/04921503-ae47-4353-80c0-e448bb05feec" />
 </p>
+
 
 **Multi-LiDAR fusion node for ROS 2** that merges any mix of PointCloud2 and LaserScan sources into a unified output, with optional CUDA GPU acceleration.
 


### PR DESCRIPTION
Mirror the hero block from the humble branch so jazzy's README also shows the multi-panel pipeline demo (fusion, filters, downsample, CUDA, perf).