### PR TITLE
feat: detect rosbag/clock misconfiguration and expose use_sim_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,35 @@ colcon build --packages-select polka --cmake-args -DWITH_CUDA=ON
    ros2 launch polka polka.launch.py config_file:=config/my_robot.yaml
    ```
 
+## Rosbag / Simulation Playback
+
+The default configuration targets **live sensor data** and runs on the system (wall)
+clock. The `source_timeout` staleness check (`0.5 s` by default) compares each message's
+header stamp against the node clock, so when you replay a rosbag — whose stamps are
+historical — every source is immediately judged stale and **no merged cloud is
+published**. Most people hit this the first time they test with a bag.
+
+To replay a bag correctly, enable simulated time **and** play the bag with `--clock` so
+the node's clock tracks bag time:
+
+```bash
+ros2 launch polka polka.launch.py use_sim_time:=true
+ros2 bag play <bag> --clock
+```
+
+| Argument | Default | Description |
+|---|---|---|
+| `use_sim_time` | `false` | Set `true` for rosbag/simulation replay; the node then uses ROS time driven by `/clock`. |
+
+If the node detects a clock/timestamp mismatch it prints a single actionable warning
+naming the fix, so you don't have to guess:
+
+- Bag stamps far behind the system clock (`use_sim_time` left `false`) → reminds you to
+  set `use_sim_time:=true` and play with `--clock`.
+- `use_sim_time:=true` but nothing publishes `/clock` → reminds you to add `--clock`.
+  (In this state the clock is frozen, so clouds may still flow on an undefined stamp —
+  always pass `--clock` for correct timing.)
+
 ## Configuration
 
 All parameters live under the `polka` namespace. [config/example_params.yaml](config/example_params.yaml) is a minimal starter; see [config/detailed_params.yaml](config/detailed_params.yaml) for the full annotated reference of every parameter.

--- a/include/polka/input/source_adapter.hpp
+++ b/include/polka/input/source_adapter.hpp
@@ -47,6 +47,7 @@ public:
 
   CloudT::ConstPtr get_latest() const;
   bool is_stale(double timeout_sec, const rclcpp::Time & now) const;
+  bool received() const { return has_received_.load(); }
   rclcpp::Time last_stamp() const;
   std::string name() const { return config_.name; }
   std::string frame_id() const;

--- a/include/polka/polka_node.hpp
+++ b/include/polka/polka_node.hpp
@@ -52,6 +52,10 @@ private:
   sensor_msgs::msg::PointCloud2 to_cloud_msg(const CloudT & cloud) const;
   bool reconfigure();
   void log_startup_banner() const;
+  // One-shot check that the node clock and the incoming sensor stamps agree. Emits a
+  // single actionable warning when they don't (the classic rosbag-without-sim-time or
+  // sim-time-without-/clock misconfiguration), then latches via clock_diagnosed_.
+  void diagnose_clock_health(const rclcpp::Time & now);
 
   MergeConfig config_;
 
@@ -79,6 +83,9 @@ private:
   std::vector<float> last_scan_ranges_;
   rclcpp::Time last_cloud_stamp_;
   mutable std::mutex last_data_mutex_;
+
+  // Set once diagnose_clock_health() has emitted its warning, so it stays quiet after.
+  bool clock_diagnosed_{false};
 
   // Runtime reconfiguration
   ConfigLoader config_loader_;

--- a/launch/polka.launch.py
+++ b/launch/polka.launch.py
@@ -27,11 +27,19 @@ def generate_launch_description():
 
     return LaunchDescription([
         DeclareLaunchArgument('config_file', default_value=default_config),
+        # Default false for live sensor data. Set true to replay a rosbag, and play the
+        # bag with the --clock flag (ros2 bag play <bag> --clock) so the staleness check
+        # compares against bag time rather than wall time:
+        #   ros2 launch polka polka.launch.py use_sim_time:=true
+        DeclareLaunchArgument('use_sim_time', default_value='false'),
         Node(
             package='polka',
             executable='polka_node',
             name='polka',
             output='screen',
-            parameters=[LaunchConfiguration('config_file')],
+            parameters=[
+                LaunchConfiguration('config_file'),
+                {'use_sim_time': LaunchConfiguration('use_sim_time')},
+            ],
         ),
     ])

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -122,9 +122,53 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
     });
 }
 
+void PolkaNode::diagnose_clock_health(const rclcpp::Time & now)
+{
+  if (clock_diagnosed_) return;
+
+  // Newest sensor stamp across sources that have actually received data. Without any
+  // data there is nothing to compare the clock against, so we can't judge yet.
+  rclcpp::Time newest;
+  bool any = false;
+  for (const auto & src : sources_) {
+    if (!src->received()) continue;
+    auto stamp = src->last_stamp();
+    if (!any || stamp > newest) { newest = stamp; any = true; }
+  }
+  if (!any) return;
+
+  const double dt = (now - newest).seconds();
+  const bool sim = this->get_parameter("use_sim_time").as_bool();
+
+  // Allow normal jitter (and the correct --clock case): only react when the clock and
+  // the data disagree by several staleness windows.
+  const double mismatch = std::max(2.0, config_.source_timeout * 4.0);
+  if (std::fabs(dt) < mismatch) return;
+
+  if (sim && count_publishers("/clock") == 0) {
+    // Sim time requested but nothing drives /clock, so the clock is frozen near zero.
+    RCLCPP_WARN(get_logger(),
+      "polka: use_sim_time=true but no publisher on /clock was found — the simulated "
+      "clock is not advancing, so timestamp/staleness checks are unreliable. If you are "
+      "replaying a rosbag, play it with the --clock flag: ros2 bag play <bag> --clock");
+    clock_diagnosed_ = true;
+  } else if (!sim && dt > mismatch) {
+    // Wall clock vs historical bag stamps: every source will be dropped as stale.
+    RCLCPP_WARN(get_logger(),
+      "polka: sensor timestamps are %.1f s behind the system clock. This looks like "
+      "rosbag replay without simulated time; all sources will be dropped as stale and "
+      "no merged cloud will be published. Set use_sim_time:=true and replay with the "
+      "--clock flag: ros2 bag play <bag> --clock", dt);
+    clock_diagnosed_ = true;
+  }
+  // Otherwise (e.g. sim time enabled and /clock present but not yet synced at startup)
+  // leave clock_diagnosed_ unset and re-evaluate on the next tick — no false alarm.
+}
+
 void PolkaNode::output_callback()
 {
   auto now = this->now();
+  diagnose_clock_health(now);
 
   struct SourceData {
     CloudT::ConstPtr cloud;


### PR DESCRIPTION
## Problem

Polka's `source_timeout` staleness check compares each message's header stamp against the node clock (`now = this->now()`). With the default config, replaying a rosbag runs the node on the **wall clock** while the bag's stamps are **historical**, so every source is immediately judged stale and **no merged cloud is published** — a silent, confusing first-run failure. The existing throttled `"source 'X' is stale"` warning reads like a sensor dropout, not a clock-config problem.

## Changes

- **Self-diagnosis**: new one-shot `diagnose_clock_health()` (called at the top of `output_callback`) compares the newest received sensor stamp against the node clock and, on a multi-window mismatch, emits a single actionable warning naming the exact fix. Covers both failure modes:
  - `use_sim_time:=false` + historical bag stamps → "set `use_sim_time:=true` and replay with `--clock`".
  - `use_sim_time:=true` but no `/clock` publisher (frozen sim clock) → "play with `--clock`".
  - Stays silent once clock and data agree (healthy band = `max(2.0, source_timeout*4)`), and does not fire during the startup window before `/clock` syncs.
- **`received()` accessor** on `SourceAdapter` so the diagnostic distinguishes "no data yet" from "data, wrong clock".
- **`use_sim_time` launch argument** (default `false`) in `polka.launch.py`, matching the `ndt_localization` convention. Override for replay: `ros2 launch polka polka.launch.py use_sim_time:=true`.
- **README**: new "Rosbag / Simulation Playback" section documenting the correct `use_sim_time:=true` + `ros2 bag play --clock` recipe.

No change to the staleness behaviour itself — detection + clear guidance only.

## Verification

- `colcon build --packages-select polka` succeeds.
- `ros2 launch polka polka.launch.py --show-args` lists `use_sim_time` (default `false`).
