### PR TITLE
perf: skip redundant SE(3) left Jacobian in rotation only deskew

### DIFF
--- a/DESKEW_PERF_REPORT.md
+++ b/DESKEW_PERF_REPORT.md
@@ -1,0 +1,197 @@
+# IMU Deskew: Correctness Gate + Measured Performance
+
+Investigation on the real moving bag `real_slam_20260713_155904_0.mcap` (99s, 3 LiDARs +
+3 IMUs, articulated chassis). Branch `ao/polka-9/deskew-perf-investigation` off `humble`.
+
+## Environment
+
+- Build/run: shared `isaac_ros_dev-x86_64-container` (ROS humble, CUDA 12.6 toolkit),
+  source copied to `/home/pan-navigator/workspaces/polka9_ws/src/polka`, bag hardlinked
+  in. Runtime tests isolated on `ROS_DOMAIN_ID=129` to avoid interfering with another
+  session's active nodes in the same container.
+- GPU is Blackwell (compute capability 12.0 / sm_120). The available CUDA 12.6 toolkit
+  only supports up to `compute_90` SASS, and the repo's `CMAKE_CUDA_ARCHITECTURES`
+  (`75;86;87`) doesn't cover sm_120 either way. Built CUDA with
+  `-DCMAKE_CUDA_ARCHITECTURES=90-virtual` (PTX-only for compute_90); the CUDA-13-capable
+  driver JIT-compiles it to sm_120 SASS at load. Verified this runs correctly (no
+  `cudaErrorNoKernelImageForDevice`). This is a local test-rig setting only, **not**
+  committed — unrelated to the deskew/perf changes.
+- The bag's per-topic QoS metadata records `history: unknown, depth: 0` uniformly across
+  every topic, which crashes `ros2 bag play`'s QoS-profile-to-`rclcpp::QoS` conversion
+  (works fine for `ros2 bag info`, which doesn't need to construct real QoS objects).
+  Fixed with `--qos-profile-overrides-path` supplying `{history: keep_last, depth: N}`
+  per topic. Environment quirk, not a polka issue.
+
+## Part A — Correctness gate: **PASS** (with one caveat, see below)
+
+**Setup:** 3-source config (`airy_front/left_front/rear`), per-source IMU (1:1
+lidar↔IMU), `output_frame_id: base_footprint`, all filters/voxel off,
+`point_timestamps.enabled: false`. Only `motion_compensation.enabled` differs between
+ON/OFF runs. Replay via `ros2 bag play --clock --qos-profile-overrides-path ...` with
+`use_sim_time:=true`; node launched with `-r __node:=polka_test` to avoid colliding
+with the bag's recorded `/polka/merged_cloud` reference.
+
+**Confirmed facts about this bag:**
+- Per-point `timestamp` field (FLOAT64, absolute epoch) is present and correctly
+  detected on all 3 sources (`"polka: source '<name>' detected per-point timestamp
+  field 'timestamp' (offset=18, FLOAT64)"` in the node log) — deskew genuinely
+  activates, not the whole-scan fallback.
+- IMU `orientation_covariance[0] == -1.0` on all 3 IMUs → gravity is never subtracted →
+  deskew here is **rotation-only** (confirmed both offline and via the node's own log:
+  `"IMU has no orientation — cannot subtract gravity, translation deskew disabled
+  (rotation-only)"`). This is a real characteristic of this rig, not a bug.
+
+**Primary metric — per-point displacement, ON vs OFF, same scan (deterministic with
+reliable QoS on the source subscriptions):**
+
+| Instant | mean IMU \|ω\| | range bin | mean displacement | max displacement |
+|---|---|---|---|---|
+| bag t≈62.0s (calm) | ≈0.035 rad/s | 10–20 m | 0.46 cm | 1.12 cm |
+| bag t≈62.48s (peak) | ≈0.6–0.74 rad/s | 10–20 m | 17.5 cm | 38.9 cm |
+| bag t≈62.48s (peak) | ≈0.6–0.74 rad/s | 0–2 m | 1.17 cm | 20.4 cm |
+
+The effect is near-zero when the platform is calm and grows by ~35x when angular rate
+rises by ~20x, scaling with range exactly as `displacement ∝ range · ω · dt` predicts.
+This rules out ON≈OFF and rules out the difference being timing jitter — it tracks the
+IMU-measured motion.
+
+**What I could not establish:** whether the correction moves points in the objectively
+*correct* direction (closer to true geometry), as opposed to merely *different*. Three
+independent attempts were inconclusive:
+- Odom-frame multi-scan accumulation (the intended check — deskew should sharpen a
+  static structure viewed from a world-fixed frame across several scans) hit persistent
+  TF instability (`"Detected jump back in time. Clearing TF buffer"` cascades) specific
+  to the `odom` frame in this container/bag combination that I could not resolve within
+  reasonable effort.
+- Comparing against the bag's recorded `/polka/merged_cloud` reference was invalidated
+  by a config/filter mismatch (recorded stream has 30k pts/scan vs. my ~250k — the
+  original recording used per-source filters I don't have, so ON and OFF were roughly
+  equally far from the reference and it carries no signal).
+- An independent Python reimplementation of the exact `delta.inverse()*p` formula
+  against raw bag data was noisy at the point of comparison (rear source, short range)
+  because the IMU sample the live node actually used at that instant can't be
+  reconstructed exactly offline (200 Hz IMU vs. real-time callback timing) — the
+  reconstruction residual (~12mm) exceeded the effect being measured (~6mm) there.
+- Ground-plane / far-structure thickness metrics (RANSAC and PCA) were tried and are
+  **not** sensitive here: 90% of candidate points are under 3m (where deskew moves
+  things <1cm) and are polluted by real clutter; the far-range (10–20m) shell in this
+  scene is a heterogeneous 3D structure (trees/overhangs), not a single flat surface,
+  so plane-fit thickness is dominated by real scene geometry, not smear.
+
+**Supporting evidence for direction, not proof:** the implementation follows the
+published, standard rko_lio SE(3)-exponential-map convention
+(`corrected = delta.inverse() * p`), and this exact code path already went through one
+documented bug-fix pass (`"Fix IMU→sensor frame rotation in deskew"`). I did not find
+evidence of a sign/frame error, but I also could not positively rule one out with the
+tools available in the time spent. **This is the one open item in the gate** — flagging
+it explicitly rather than papering over it.
+
+No rviz screenshot pair was obtained: X11 forwarding into the shared container did not
+work within a reasonable debugging budget (`qt.qpa.xcb: could not connect to display`).
+Matplotlib visualizations of the same point sets were generated instead
+(`far_range_on_vs_off_62479.png`, `side_view_62_479.png` in the session scratchpad) but
+did not show an obvious visual smear/sharpen difference at the specific far-range
+region examined — consistent with that region being a poor place to *see* the effect
+(see far-range thickness note above); the quantitative displacement table above is the
+decisive evidence, not these images.
+
+## Part B — Performance
+
+### Profiling
+
+`perf` isn't packaged for this host's kernel (6.17.0-1028-oem, no matching
+`linux-tools`). Used a standalone microbenchmark plus an in-loop bypass test instead.
+Bypassing `compute_motion_delta()` entirely (hardcoding an identity transform) dropped
+the per-scan deskew loop from ~10ms to ~0.7–1.3ms — **the SE(3) motion-delta computation
+accounts for ~85–90% of deskew's cost**, confirming it as the hottest stage.
+
+Looking at `se3_exp()`: the SO(3) left Jacobian `V` (norm, skew matrix, two trig calls,
+one matrix square) is computed unconditionally to produce `T.translation() = V * rho`.
+When `rho` is exactly the zero vector — which it always is in rotation-only mode, since
+`rho = accel * 0.5*dt²` and `accel` is zeroed — `V * 0 == 0` regardless of `V`, making
+that entire computation provably wasted work.
+
+### Optimization
+
+Skip the left-Jacobian computation when `rho.squaredNorm() > 0.0` is false
+(`include/polka/util/se3_exp.hpp`). This is a mathematically exact no-op skip when it
+fires, not an approximation — `T.translation()` was going to be the zero vector either
+way (`Isometry3d::Identity()`'s default).
+
+### Baseline vs optimized (CPU, per-source deskew, mean over 50-call rolling windows)
+
+Clean back-to-back A/B (same container, same bag window, immediately sequential runs,
+to rule out time-varying system effects like thermal state):
+
+| Stage | Baseline | Optimized | Change |
+|---|---|---|---|
+| Deskew, per source (86.4k pts) | ~11.1–12.1 ms | ~8.5–9.9 ms | **~20% reduction** |
+| Merge (CPU) | ~5.1–5.2 ms | ~5.9–6.1 ms | no change (not touched; run-to-run noise) |
+| Throughput | 9.95 Hz | 9.95 Hz | unchanged (not throughput-bound at 10Hz) |
+
+An isolated microbenchmark of just the `se3_exp`/`compute_motion_delta` computation
+(same header, same `-O3 -DNDEBUG` flags as the real build) showed a larger ~2x speedup
+in isolation; the smaller ~20% gain embedded in the full node is real and reproducible
+(confirmed via a clean back-to-back rebuild-and-rerun A/B, not a one-off), most likely
+because sustained multi-threaded load (bag player + DDS + 3 concurrent source
+callbacks) throttles the CPU below the burst clock a brief isolated benchmark gets.
+
+Combined effect: total per-tick CPU spent in deskew across all 3 sources drops from
+~34.5ms to ~27.6ms — about 7ms/tick of headroom recovered, on a 100ms tick budget at
+10Hz output.
+
+### CUDA build
+
+Deskew is always CPU code (`source_adapter.cpp`) regardless of merge engine — the
+~20% deskew improvement applies identically to CUDA builds.
+
+| Stage | Baseline | Optimized |
+|---|---|---|
+| Deskew, per source | ~11.1–11.7 ms | ~9.9–10.3 ms |
+| Merge (CUDA, steady-state after PTX-JIT warmup) | ~11.2–11.6 ms | ~9.7–10.9 ms |
+
+The GPU merge path is currently **slower than the CPU merge path** for this specific
+workload (no output filters, no voxel downsampling — effectively transform + copy).
+This is a genuine, reportable finding, not a regression I introduced: with this little
+per-point work, fixed GPU-dispatch/transfer overhead (H2D/D2H copies, kernel launch)
+outweighs any parallelism benefit. GPU acceleration would likely pay off more with
+voxel downsampling or heavier per-point filtering enabled — not tested here (out of
+scope for this bag's config). The one-time PTX-JIT compilation on first kernel launch
+(from the `90-virtual` build) costs ~100–140ms on the very first call; excluded from
+the steady-state numbers above.
+
+### Re-check correctness (no regression)
+
+Same single scan (bag t≈62.35s, index-matched, reliable QoS), baseline vs optimized
+build:
+
+- Optimized vs baseline: mean displacement 0.27cm, max 8.53cm.
+- **Noise floor** (same unmodified baseline binary run twice): mean 1.17cm, max 33.9cm.
+
+The optimized build's deviation from baseline is *smaller* than the natural run-to-run
+variance of the identical, unmodified binary (this variance itself comes from which
+exact IMU sample among the ~20 arriving per 100ms window the live subscriber happens to
+have on hand at callback time — inherent real-time nondeterminism, not a bug). No
+measurable correctness regression from the optimization.
+
+## What changed
+
+- `include/polka/util/se3_exp.hpp`: skip the SO(3) left-Jacobian computation when there
+  is no translation to apply (`rho` is the zero vector).
+- `src/source_adapter.cpp` / `include/polka/input/source_adapter.hpp`: rolling
+  mean/max deskew-loop latency, logged every 50 calls.
+- `src/polka_node.cpp` / `include/polka/polka_node.hpp`: rolling mean/max merge-stage
+  latency (CPU and CUDA paths), logged every 50 calls.
+
+## Verdict
+
+- Correctness: PASS on the primary controlled comparison (displacement scales with
+  range and with IMU-measured motion as expected); direction-of-correction is
+  plausible but not independently proven — flagged as an open item above, not glossed
+  over.
+- Performance: ~20% reduction in the dominant per-scan cost (deskew), safe (exact
+  no-op skip, re-check confirms no regression beyond natural noise), reproducible.
+  Worth merging.
+- CUDA merge being slower than CPU merge for this no-filter config is reported as-is;
+  no attempt was made to "fix" it since it wasn't the profiled hot stage for this task
+  and isn't a regression from this change.

--- a/DESKEW_PERF_REPORT.md
+++ b/DESKEW_PERF_REPORT.md
@@ -3,6 +3,22 @@
 Investigation on the real moving bag `real_slam_20260713_155904_0.mcap` (99s, 3 LiDARs +
 3 IMUs, articulated chassis). Branch `ao/polka-9/deskew-perf-investigation` off `humble`.
 
+## Falsifiable summary
+
+- **Claim:** the optimization cuts per-source deskew latency from ~11.1-12.1ms to
+  ~8.5-9.9ms (86.4k pts/scan), a ~20% reduction, with no correctness regression.
+- **How to falsify it:** rebuild both `humble` (baseline) and this branch (optimized),
+  replay the same bag window, and check the `polka: perf source '<name>' deskew:
+  mean=...ms` log line. If optimized mean is not below baseline mean, the perf claim
+  is false.
+- **Correctness tolerance:** optimized-build deskew-ON output on a fixed, stamp-matched
+  scan must differ from baseline-build deskew-ON output on the *same* scan by less than
+  the baseline binary's own run-to-run noise floor. Measured: optimized-vs-baseline
+  mean 0.27cm / max 8.53cm, noise floor (baseline vs itself, rerun) mean 1.17cm / max
+  33.9cm. Optimized is within the noise floor on both axes, so the tolerance is met. If
+  a future change pushes optimized-vs-baseline past ~1.2cm mean or ~34cm max on this
+  same scan, treat it as a regression.
+
 ## Environment
 
 - Build/run: shared `isaac_ros_dev-x86_64-container` (ROS humble, CUDA 12.6 toolkit),
@@ -182,6 +198,51 @@ measurable correctness regression from the optimization.
   mean/max deskew-loop latency, logged every 50 calls.
 - `src/polka_node.cpp` / `include/polka/polka_node.hpp`: rolling mean/max merge-stage
   latency (CPU and CUDA paths), logged every 50 calls.
+- Repo-wide `ament_uncrustify --reformat` plus scripted header-guard renames and
+  include-order fixes across the package, to get CI's lint suite (cpplint, uncrustify)
+  green — these were pre-existing failures on `humble` itself (verified by running the
+  same checks against an unmodified `humble` checkout before touching anything),
+  unrelated to the deskew work, but blocking this PR's CI. `colcon test` now shows all
+  7 lint/style checks passing locally against this exact branch state.
+
+## Follow-up (specced, not implemented here)
+
+Even after skipping the left-Jacobian, the remaining cost is still one full SE(3)
+exponential map (`AngleAxisd` + `sin`/`cos` + rotation-matrix build + `Isometry3d`
+inverse + 3x3 matvec) **per point** — confirmed the dominant remaining cost by the
+bypass test in "Profiling" above (~8.3-9.3ms of the ~9-10ms optimized deskew loop, i.e.
+still ~85-90% of it). For one 86.4k-point scan at the measured per-source rate, that's
+roughly 95-110ns/point of transcendental-function work, repeated independently for
+every point even though within one scan `angular_vel` is fixed and only `dt` varies
+linearly with azimuth.
+
+**Proposed fix:** precompute `exp(ω·dt) [+ 0.5·a·dt² when accel is available]` at a
+coarse stride — e.g. once per ring, or every N-th point (N≈16-32) along the scan — and
+linearly interpolate the SE(3) delta (or just the rotation angle, since `ω` is constant
+within a scan and the rotation axis is fixed, so only the angle magnitude needs
+interpolating) for the points in between. This cuts transcendental-function calls by
+roughly the stride factor (~5-10x fewer `sin`/`cos`/`AngleAxisd` evaluations) at the
+cost of a bounded linear-interpolation error between anchor points, which is small
+because `dt` (and hence the rotation angle) varies smoothly and monotonically across
+a scan — the same continuity the current per-point exact computation exists to avoid
+losing wholesale.
+
+**Bounded accuracy loss:** worst case, the interpolation error is the second-derivative
+term dropped by linearizing `exp()` between anchors, which scales with `(stride ·
+Δdt)²·|ω|²/2` — for stride=16 points out of ~86.4k over a 100ms scan (Δdt per point
+≈1.16µs, so anchor spacing ≈18.5µs) and `|ω|` up to the peak ~0.74 rad/s measured in
+Part A, this is several orders of magnitude below the ~1cm displacement noise floor
+already established as acceptable above — i.e., the interpolation error should be
+undetectable against the existing measurement noise, but this needs to be verified
+empirically (compare interpolated vs exact per-point output, same tolerance framework
+as the re-check above) before merging, not assumed.
+
+**Where to implement:** `SourceAdapter::deskew_cloud()` in `src/source_adapter.cpp` —
+replace the per-point `compute_motion_delta(angular_vel, accel, dt)` call with a
+precompute pass every `kDeskewInterpStride` points, then interpolate between anchors
+for the points in between. Left unimplemented here due to context budget; specced
+concretely enough to build and measure directly against this report's tolerance
+framework.
 
 ## Verdict
 

--- a/include/polka/config/config_loader.hpp
+++ b/include/polka/config/config_loader.hpp
@@ -12,15 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__CONFIG__CONFIG_LOADER_HPP
-#define POLKA__CONFIG__CONFIG_LOADER_HPP
+#ifndef POLKA__CONFIG__CONFIG_LOADER_HPP_
+#define POLKA__CONFIG__CONFIG_LOADER_HPP_
+
+#include <string>
+#include <vector>
 
 #include "polka/types.hpp"
 #include <rclcpp/rclcpp.hpp>
 
-namespace polka {
+namespace polka
+{
 
-class ConfigLoader {
+class ConfigLoader
+{
 public:
   explicit ConfigLoader(rclcpp::Node * node);
   MergeConfig load();
@@ -40,4 +45,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__CONFIG__CONFIG_LOADER_HPP
+#endif  // POLKA__CONFIG__CONFIG_LOADER_HPP_

--- a/include/polka/filters/angular_filter.hpp
+++ b/include/polka/filters/angular_filter.hpp
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__FILTERS__ANGULAR_FILTER_HPP
-#define POLKA__FILTERS__ANGULAR_FILTER_HPP
+#ifndef POLKA__FILTERS__ANGULAR_FILTER_HPP_
+#define POLKA__FILTERS__ANGULAR_FILTER_HPP_
 
-#include "polka/filters/i_filter.hpp"
+#include <string>
 #include <vector>
 #include <utility>
 
-namespace polka {
+#include "polka/filters/i_filter.hpp"
 
-class AngularFilter : public IFilter {
+namespace polka
+{
+
+class AngularFilter : public IFilter
+{
 public:
   AngularFilter(const std::vector<std::pair<double, double>> & ranges_deg, bool invert);
   void apply(CloudT & cloud, const std::string & frame_id) override;
@@ -34,4 +38,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__FILTERS__ANGULAR_FILTER_HPP
+#endif  // POLKA__FILTERS__ANGULAR_FILTER_HPP_

--- a/include/polka/filters/box_filter.hpp
+++ b/include/polka/filters/box_filter.hpp
@@ -12,18 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__FILTERS__BOX_FILTER_HPP
-#define POLKA__FILTERS__BOX_FILTER_HPP
+#ifndef POLKA__FILTERS__BOX_FILTER_HPP_
+#define POLKA__FILTERS__BOX_FILTER_HPP_
 
-#include "polka/filters/i_filter.hpp"
 #include <Eigen/Core>
 
-namespace polka {
+#include <string>
 
-class BoxFilter : public IFilter {
+#include "polka/filters/i_filter.hpp"
+
+namespace polka
+{
+
+class BoxFilter : public IFilter
+{
 public:
-  BoxFilter(const Eigen::Vector3d & box_min, const Eigen::Vector3d & box_max,
-            bool invert = false);
+  BoxFilter(
+    const Eigen::Vector3d & box_min, const Eigen::Vector3d & box_max,
+    bool invert = false);
   void apply(CloudT & cloud, const std::string & frame_id) override;
 
 private:
@@ -33,4 +39,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__FILTERS__BOX_FILTER_HPP
+#endif  // POLKA__FILTERS__BOX_FILTER_HPP_

--- a/include/polka/filters/filter_chain.hpp
+++ b/include/polka/filters/filter_chain.hpp
@@ -15,28 +15,32 @@
 #ifndef POLKA__FILTERS__FILTER_CHAIN_HPP_
 #define POLKA__FILTERS__FILTER_CHAIN_HPP_
 
+#include <memory>
+#include <vector>
+
 #include "polka/types.hpp"
 #include "polka/filters/i_filter.hpp"
 #include "polka/filters/range_filter.hpp"
 #include "polka/filters/angular_filter.hpp"
 #include "polka/filters/box_filter.hpp"
 
-#include <memory>
-#include <vector>
-
-namespace polka {
+namespace polka
+{
 
 /// Build a filter chain from a FilterParams config.
 /// Returns an ordered vector: range → angular → box (enabled filters only).
 inline std::vector<std::unique_ptr<IFilter>> build_filter_chain(const FilterParams & fp)
 {
   std::vector<std::unique_ptr<IFilter>> chain;
-  if (fp.range_filter_enabled)
+  if (fp.range_filter_enabled) {
     chain.push_back(std::make_unique<RangeFilter>(fp.min_range, fp.max_range));
-  if (fp.angular_filter_enabled && !fp.angular_ranges.empty())
+  }
+  if (fp.angular_filter_enabled && !fp.angular_ranges.empty()) {
     chain.push_back(std::make_unique<AngularFilter>(fp.angular_ranges, fp.angular_invert));
-  if (fp.box_filter_enabled)
+  }
+  if (fp.box_filter_enabled) {
     chain.push_back(std::make_unique<BoxFilter>(fp.box_min, fp.box_max));
+  }
   return chain;
 }
 

--- a/include/polka/filters/i_filter.hpp
+++ b/include/polka/filters/i_filter.hpp
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__FILTERS__I_FILTER_HPP
-#define POLKA__FILTERS__I_FILTER_HPP
+#ifndef POLKA__FILTERS__I_FILTER_HPP_
+#define POLKA__FILTERS__I_FILTER_HPP_
 
-#include "polka/types.hpp"
 #include <string>
 
-namespace polka {
+#include "polka/types.hpp"
 
-class IFilter {
+namespace polka
+{
+
+class IFilter
+{
 public:
   virtual void apply(CloudT & cloud, const std::string & frame_id) = 0;
   virtual ~IFilter() = default;
@@ -28,4 +31,4 @@ public:
 
 }  // namespace polka
 
-#endif  // POLKA__FILTERS__I_FILTER_HPP
+#endif  // POLKA__FILTERS__I_FILTER_HPP_

--- a/include/polka/filters/range_filter.hpp
+++ b/include/polka/filters/range_filter.hpp
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__FILTERS__RANGE_FILTER_HPP
-#define POLKA__FILTERS__RANGE_FILTER_HPP
+#ifndef POLKA__FILTERS__RANGE_FILTER_HPP_
+#define POLKA__FILTERS__RANGE_FILTER_HPP_
+
+#include <string>
 
 #include "polka/filters/i_filter.hpp"
 
-namespace polka {
+namespace polka
+{
 
-class RangeFilter : public IFilter {
+class RangeFilter : public IFilter
+{
 public:
   RangeFilter(double min_range, double max_range);
   void apply(CloudT & cloud, const std::string & frame_id) override;
@@ -31,4 +35,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__FILTERS__RANGE_FILTER_HPP
+#endif  // POLKA__FILTERS__RANGE_FILTER_HPP_

--- a/include/polka/input/imu_buffer.hpp
+++ b/include/polka/input/imu_buffer.hpp
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__INPUT__IMU_BUFFER_HPP
-#define POLKA__INPUT__IMU_BUFFER_HPP
+#ifndef POLKA__INPUT__IMU_BUFFER_HPP_
+#define POLKA__INPUT__IMU_BUFFER_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/imu.hpp>
 #include <Eigen/Core>
 
 #include <deque>
@@ -24,22 +22,29 @@
 #include <mutex>
 #include <string>
 
-namespace polka {
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/imu.hpp>
 
-struct ImuSample {
+namespace polka
+{
+
+struct ImuSample
+{
   double wx = 0.0, wy = 0.0, wz = 0.0;   // angular velocity (rad/s)
   double ax = 0.0, ay = 0.0, az = 0.0;    // linear acceleration (m/s²)
   rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
 };
 
-struct AveragedImu {
+struct AveragedImu
+{
   Eigen::Vector3d angular_vel = Eigen::Vector3d::Zero();
   Eigen::Vector3d linear_accel = Eigen::Vector3d::Zero();
   bool valid = false;
   std::string frame_id;
 };
 
-class ImuBuffer {
+class ImuBuffer
+{
 public:
   ImuBuffer(rclcpp::Node * node, const std::string & topic, int buffer_size);
 
@@ -59,4 +64,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__INPUT__IMU_BUFFER_HPP
+#endif  // POLKA__INPUT__IMU_BUFFER_HPP_

--- a/include/polka/input/source_adapter.hpp
+++ b/include/polka/input/source_adapter.hpp
@@ -105,6 +105,11 @@ private:
   // Per-source IMU (when configured) and TF for frame rotation
   std::shared_ptr<ImuBuffer> local_imu_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+
+  // Perf instrumentation: rolling deskew-loop latency, logged every N calls.
+  uint64_t deskew_calls_{0};
+  double deskew_total_us_{0.0};
+  double deskew_max_us_{0.0};
 };
 
 }  // namespace polka

--- a/include/polka/input/source_adapter.hpp
+++ b/include/polka/input/source_adapter.hpp
@@ -12,20 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__INPUT__SOURCE_ADAPTER_HPP
-#define POLKA__INPUT__SOURCE_ADAPTER_HPP
+#ifndef POLKA__INPUT__SOURCE_ADAPTER_HPP_
+#define POLKA__INPUT__SOURCE_ADAPTER_HPP_
 
-#include "polka/types.hpp"
-#include "polka/input/imu_buffer.hpp"
-#include "polka/filters/i_filter.hpp"
-
-#include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
-#include <laser_geometry/laser_geometry.hpp>
 #include <tf2_ros/buffer.h>
-
 #include <Eigen/Core>
+
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -33,26 +25,37 @@
 #include <vector>
 #include <atomic>
 
-namespace polka {
+#include "polka/types.hpp"
+#include "polka/input/imu_buffer.hpp"
+#include "polka/filters/i_filter.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <laser_geometry/laser_geometry.hpp>
 
-class SourceAdapter {
+namespace polka
+{
+
+class SourceAdapter
+{
 public:
   using ImuGetter = std::function<std::shared_ptr<const AveragedImu>()>;
 
-  SourceAdapter(rclcpp::Node * node, const SourceConfig & config, bool gpu_filters = false,
-                ImuGetter imu_getter = nullptr, bool deskew_enabled = false,
-                const std::string & timestamp_field_hint = "auto",
-                std::shared_ptr<tf2_ros::Buffer> tf_buffer = nullptr,
-                int imu_buffer_size = 200);
+  SourceAdapter(
+    rclcpp::Node * node, const SourceConfig & config, bool gpu_filters = false,
+    ImuGetter imu_getter = nullptr, bool deskew_enabled = false,
+    const std::string & timestamp_field_hint = "auto",
+    std::shared_ptr<tf2_ros::Buffer> tf_buffer = nullptr,
+    int imu_buffer_size = 200);
 
   CloudT::ConstPtr get_latest() const;
   bool is_stale(double timeout_sec, const rclcpp::Time & now) const;
-  bool received() const { return has_received_.load(); }
+  bool received() const {return has_received_.load();}
   rclcpp::Time last_stamp() const;
-  std::string name() const { return config_.name; }
+  std::string name() const {return config_.name;}
   std::string frame_id() const;
-  uint64_t message_count() const { return message_counter_.load(); }
-  const FilterParams & filter_params() const { return config_.filter_params; }
+  uint64_t message_count() const {return message_counter_.load();}
+  const FilterParams & filter_params() const {return config_.filter_params;}
   void rebuild_filters(const FilterParams & fp);
 
 private:
@@ -67,8 +70,9 @@ private:
   double extract_point_time(const uint8_t * point_data) const;
   // Fill each point's 'time' field with its absolute acquisition time (Unix sec).
   void populate_point_time(CloudT & cloud, const sensor_msgs::msg::PointCloud2 & raw_msg);
-  void deskew_cloud(CloudT & cloud, const sensor_msgs::msg::PointCloud2 & raw_msg,
-                    const AveragedImu & imu);
+  void deskew_cloud(
+    CloudT & cloud, const sensor_msgs::msg::PointCloud2 & raw_msg,
+    const AveragedImu & imu);
 
   rclcpp::Node * node_;
   SourceConfig config_;
@@ -114,4 +118,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__INPUT__SOURCE_ADAPTER_HPP
+#endif  // POLKA__INPUT__SOURCE_ADAPTER_HPP_

--- a/include/polka/merge_engine/cpu_merge_engine.hpp
+++ b/include/polka/merge_engine/cpu_merge_engine.hpp
@@ -15,14 +15,18 @@
 #ifndef POLKA__MERGE_ENGINE__CPU_MERGE_ENGINE_HPP_
 #define POLKA__MERGE_ENGINE__CPU_MERGE_ENGINE_HPP_
 
+#include <vector>
+
 #include "polka/merge_engine/i_merge_engine.hpp"
 
-namespace polka {
+namespace polka
+{
 
-class CpuMergeEngine : public IMergeEngine {
+class CpuMergeEngine : public IMergeEngine
+{
 public:
   CloudT::Ptr merge(const std::vector<MergeInput> & sources) override;
-  bool is_gpu() const override { return false; }
+  bool is_gpu() const override {return false;}
 };
 
 }  // namespace polka

--- a/include/polka/merge_engine/cuda_merge_engine.hpp
+++ b/include/polka/merge_engine/cuda_merge_engine.hpp
@@ -12,22 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP
-#define POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP
+#ifndef POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP_
+#define POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP_
 
 #ifdef POLKA_CUDA_ENABLED
 
+#include <vector>
+
 #include "polka/merge_engine/i_merge_engine.hpp"
 
-namespace polka {
+namespace polka
+{
 
-class CudaMergeEngine : public IMergeEngine {
+class CudaMergeEngine : public IMergeEngine
+{
 public:
   explicit CudaMergeEngine(const MergeConfig & config);
   ~CudaMergeEngine() override;
 
   CloudT::Ptr merge(const std::vector<MergeInput> & sources) override;
-  bool is_gpu() const override { return true; }
+  bool is_gpu() const override {return true;}
 
   PipelineResult merge_pipeline(
     const std::vector<MergeInput> & sources,
@@ -41,4 +45,4 @@ private:
 }  // namespace polka
 
 #endif  // POLKA_CUDA_ENABLED
-#endif  // POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP
+#endif  // POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP_

--- a/include/polka/merge_engine/i_merge_engine.hpp
+++ b/include/polka/merge_engine/i_merge_engine.hpp
@@ -12,23 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP
-#define POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP
+#ifndef POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP_
+#define POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP_
 
-#include "polka/types.hpp"
-#include <vector>
 #include <Eigen/Geometry>
 
-namespace polka {
+#include <vector>
 
-struct MergeInput {
+#include "polka/types.hpp"
+
+namespace polka
+{
+
+struct MergeInput
+{
   CloudT::ConstPtr cloud;
   Eigen::Isometry3d transform;
   FilterParams filter_params;
 };
 
 // Full GPU pipeline configuration - captures everything needed post-merge
-struct PipelineConfig {
+struct PipelineConfig
+{
   FilterParams output_filters;
   bool self_filter_enabled = false;
   std::vector<ExclusionBox> self_filter_boxes;
@@ -38,12 +43,14 @@ struct PipelineConfig {
   FlattenParams flatten;
 };
 
-struct PipelineResult {
+struct PipelineResult
+{
   CloudT::Ptr cloud;
   std::vector<float> scan_ranges;  // non-empty only when GPU produces scan
 };
 
-class IMergeEngine {
+class IMergeEngine
+{
 public:
   virtual CloudT::Ptr merge(const std::vector<MergeInput> & sources) = 0;
   virtual bool is_gpu() const = 0;
@@ -62,4 +69,4 @@ public:
 
 }  // namespace polka
 
-#endif  // POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP
+#endif  // POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP_

--- a/include/polka/output/output_pipeline.hpp
+++ b/include/polka/output/output_pipeline.hpp
@@ -15,19 +15,21 @@
 #ifndef POLKA__OUTPUT__OUTPUT_PIPELINE_HPP_
 #define POLKA__OUTPUT__OUTPUT_PIPELINE_HPP_
 
-#include "polka/types.hpp"
-#include "polka/filters/i_filter.hpp"
-#include "polka/merge_engine/i_merge_engine.hpp"
-
 #include <memory>
 #include <string>
 #include <vector>
 
-namespace polka {
+#include "polka/types.hpp"
+#include "polka/filters/i_filter.hpp"
+#include "polka/merge_engine/i_merge_engine.hpp"
+
+namespace polka
+{
 
 /// CPU post-merge processing pipeline: output filters → height cap → voxel downsample.
 /// Also builds PipelineConfig for the GPU engine path.
-class OutputPipeline {
+class OutputPipeline
+{
 public:
   void configure(const CloudOutputConfig & cfg);
 

--- a/include/polka/output/scan_builder.hpp
+++ b/include/polka/output/scan_builder.hpp
@@ -15,22 +15,24 @@
 #ifndef POLKA__OUTPUT__SCAN_BUILDER_HPP_
 #define POLKA__OUTPUT__SCAN_BUILDER_HPP_
 
-#include "polka/types.hpp"
-
-#include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
-
 #include <string>
 #include <vector>
 
-namespace polka {
+#include "polka/types.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+
+namespace polka
+{
 
 /// Builds sensor_msgs::LaserScan from a merged PointCloud2 or a pre-computed range vector.
 /// Centralises header assembly so both CPU and GPU paths share the same stamp/frame logic.
-class ScanBuilder {
+class ScanBuilder
+{
 public:
-  void configure(const ScanOutputConfig & cfg, double output_rate,
-                 const std::string & frame_id);
+  void configure(
+    const ScanOutputConfig & cfg, double output_rate,
+    const std::string & frame_id);
 
   /// Project a 3D cloud to a 2D LaserScan using the configured flatten parameters.
   sensor_msgs::msg::LaserScan from_cloud(

--- a/include/polka/polka_node.hpp
+++ b/include/polka/polka_node.hpp
@@ -56,6 +56,9 @@ private:
   // single actionable warning when they don't (the classic rosbag-without-sim-time or
   // sim-time-without-/clock misconfiguration), then latches via clock_diagnosed_.
   void diagnose_clock_health(const rclcpp::Time & now);
+  // Perf instrumentation: accumulates merge-stage latency, logs a mean/max every
+  // N calls. `engine_label` is just "CPU" or "CUDA" for the log line.
+  void log_merge_perf(double us, const char * engine_label);
 
   MergeConfig config_;
 
@@ -86,6 +89,11 @@ private:
 
   // Set once diagnose_clock_health() has emitted its warning, so it stays quiet after.
   bool clock_diagnosed_{false};
+
+  // Perf instrumentation: rolling merge-stage latency, logged every N calls.
+  uint64_t merge_calls_{0};
+  double merge_total_us_{0.0};
+  double merge_max_us_{0.0};
 
   // Runtime reconfiguration
   ConfigLoader config_loader_;

--- a/include/polka/polka_node.hpp
+++ b/include/polka/polka_node.hpp
@@ -15,17 +15,6 @@
 #ifndef POLKA__POLKA_NODE_HPP_
 #define POLKA__POLKA_NODE_HPP_
 
-#include "polka/types.hpp"
-#include "polka/config/config_loader.hpp"
-#include "polka/input/source_adapter.hpp"
-#include "polka/input/imu_buffer.hpp"
-#include "polka/merge_engine/i_merge_engine.hpp"
-#include "polka/output/output_pipeline.hpp"
-#include "polka/output/scan_builder.hpp"
-
-#include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <Eigen/Geometry>
@@ -35,9 +24,22 @@
 #include <string>
 #include <vector>
 
-namespace polka {
+#include "polka/types.hpp"
+#include "polka/config/config_loader.hpp"
+#include "polka/input/source_adapter.hpp"
+#include "polka/input/imu_buffer.hpp"
+#include "polka/merge_engine/i_merge_engine.hpp"
+#include "polka/output/output_pipeline.hpp"
+#include "polka/output/scan_builder.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
-class PolkaNode : public rclcpp::Node {
+namespace polka
+{
+
+class PolkaNode : public rclcpp::Node
+{
 public:
   explicit PolkaNode(const rclcpp::NodeOptions & options);
 

--- a/include/polka/types.hpp
+++ b/include/polka/types.hpp
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__TYPES_HPP
-#define POLKA__TYPES_HPP
+#ifndef POLKA__TYPES_HPP_
+#define POLKA__TYPES_HPP_
+
+#include <pcl/point_types.h>
+#include <pcl/point_cloud.h>
+#include <Eigen/Core>
 
 #include <string>
 #include <vector>
@@ -21,11 +25,8 @@
 #include <stdexcept>
 #include <utility>
 
-#include <pcl/point_types.h>
-#include <pcl/point_cloud.h>
-#include <Eigen/Core>
-
-namespace polka {
+namespace polka
+{
 
 // Point with a per-point acquisition timestamp.
 //
@@ -38,7 +39,8 @@ namespace polka {
 // At publish time, with point_timestamps.mode = OFFSET, PolkaNode::rebase_point_time
 // converts 'time' to an offset relative to the merged cloud header (the convention
 // deskewing consumers expect); with mode = ABSOLUTE it is emitted unchanged.
-struct EIGEN_ALIGN16 PointXYZIT {
+struct EIGEN_ALIGN16 PointXYZIT
+{
   PCL_ADD_POINT4D;       // adds float x, y, z (+ padding) as a SSE-aligned block
   float intensity;
   double time;
@@ -56,12 +58,14 @@ enum class TimestampStrategy { EARLIEST, LATEST, AVERAGE, LOCAL };
 //   ABSOLUTE - raw Unix seconds, as received from the source LiDAR
 enum class PerPointTimeMode { OFFSET, ABSOLUTE };
 
-struct PerPointTimeConfig {
+struct PerPointTimeConfig
+{
   bool enabled = false;                          // emit a per-point 'time' field
   PerPointTimeMode mode = PerPointTimeMode::OFFSET;
 };
 
-struct FilterParams {
+struct FilterParams
+{
   double min_range = 0.0;
   double max_range = 100.0;
   double min_range_sq = 0.0;
@@ -78,30 +82,39 @@ struct FilterParams {
   Eigen::Vector3d box_min = Eigen::Vector3d(-100.0, -100.0, -100.0);
   Eigen::Vector3d box_max = Eigen::Vector3d(100.0, 100.0, 100.0);
 
-  void compute_squared_ranges() {
+  void compute_squared_ranges()
+  {
     min_range_sq = min_range * min_range;
     max_range_sq = max_range * max_range;
   }
 
-  void validate() const {
-    if (min_range < 0)
+  void validate() const
+  {
+    if (min_range < 0) {
       throw std::invalid_argument("min_range must be non-negative");
-    if (max_range <= min_range)
+    }
+    if (max_range <= min_range) {
       throw std::invalid_argument("max_range must be greater than min_range");
+    }
     for (const auto & r : angular_ranges) {
       if (r.first < 0.0 || r.first > 360.0 ||
-          r.second < 0.0 || r.second > 360.0)
+        r.second < 0.0 || r.second > 360.0)
+      {
         throw std::invalid_argument("angular range values must be in [0, 360] degrees");
+      }
     }
     if (box_filter_enabled) {
       if (box_min.x() >= box_max.x() || box_min.y() >= box_max.y() ||
-          box_min.z() >= box_max.z())
+        box_min.z() >= box_max.z())
+      {
         throw std::invalid_argument("box_min must be less than box_max in all dimensions");
+      }
     }
   }
 };
 
-struct FlattenParams {
+struct FlattenParams
+{
   double z_min = -0.15;
   double z_max = 0.15;
   double angle_min = -3.14159265;
@@ -111,23 +124,30 @@ struct FlattenParams {
   double range_max = 100.0;
   int n_bins = 0;
 
-  void compute_bins() {
+  void compute_bins()
+  {
     n_bins = static_cast<int>((angle_max - angle_min) / angle_increment);
   }
 
-  void validate() const {
-    if (z_min >= z_max)
+  void validate() const
+  {
+    if (z_min >= z_max) {
       throw std::invalid_argument("z_min must be less than z_max");
-    if (angle_min >= angle_max)
+    }
+    if (angle_min >= angle_max) {
       throw std::invalid_argument("angle_min must be less than angle_max");
-    if (angle_increment <= 0)
+    }
+    if (angle_increment <= 0) {
       throw std::invalid_argument("angle_increment must be positive");
-    if (range_min < 0 || range_max <= range_min)
+    }
+    if (range_min < 0 || range_max <= range_min) {
       throw std::invalid_argument("range_min must be non-negative and less than range_max");
+    }
   }
 };
 
-struct SourceConfig {
+struct SourceConfig
+{
   std::string name;
   std::string topic;
   std::string imu_topic;  // per-source IMU override (empty = use global)
@@ -137,31 +157,36 @@ struct SourceConfig {
   FilterParams filter_params;
 };
 
-struct HeightCapConfig {
+struct HeightCapConfig
+{
   bool enabled = false;
   double z_min = -1.0;
   double z_max = 3.0;
 };
 
-struct VoxelConfig {
+struct VoxelConfig
+{
   bool enabled = false;
   float leaf_x = 0.0f;
   float leaf_y = 0.0f;
   float leaf_z = 0.0f;
 };
 
-struct ExclusionBox {
+struct ExclusionBox
+{
   Eigen::Vector3d min = Eigen::Vector3d::Zero();
   Eigen::Vector3d max = Eigen::Vector3d::Zero();
   std::string label;
 };
 
-struct SelfFilterConfig {
+struct SelfFilterConfig
+{
   bool enabled = false;
   std::vector<ExclusionBox> boxes;
 };
 
-struct OutputQosConfig {
+struct OutputQosConfig
+{
   std::string reliability = "reliable";
   std::string durability = "volatile";
   int history_depth = 10;
@@ -171,7 +196,8 @@ struct OutputQosConfig {
   double lifespan_ms = 0.0;
 };
 
-struct CloudOutputConfig {
+struct CloudOutputConfig
+{
   bool enabled = true;
   std::string topic = "~/merged_cloud";
   OutputQosConfig qos;
@@ -181,14 +207,16 @@ struct CloudOutputConfig {
   SelfFilterConfig self_filter;
 };
 
-struct ScanOutputConfig {
+struct ScanOutputConfig
+{
   bool enabled = false;
   std::string topic = "~/merged_scan";
   OutputQosConfig qos;
   FlattenParams flatten;
 };
 
-struct MotionCompensationConfig {
+struct MotionCompensationConfig
+{
   bool enabled = false;
   std::string imu_topic = "";                    // sensor_msgs/Imu topic
   double max_imu_age = 0.2;                      // reject stale IMU data (seconds)
@@ -198,7 +226,8 @@ struct MotionCompensationConfig {
   std::string imu_frame = "";                     // empty = auto-detect from IMU msg header
 };
 
-struct MergeConfig {
+struct MergeConfig
+{
   std::string output_frame_id = "base_link";
   double output_rate = 20.0;
   double source_timeout = 0.5;
@@ -224,10 +253,6 @@ struct MergeConfig {
 
 POINT_CLOUD_REGISTER_POINT_STRUCT(
   polka::PointXYZIT,
-  (float, x, x)
-  (float, y, y)
-  (float, z, z)
-  (float, intensity, intensity)
-  (double, time, time))
+  (float, x, x)(float, y, y)(float, z, z)(float, intensity, intensity)(double, time, time))
 
-#endif  // POLKA__TYPES_HPP
+#endif  // POLKA__TYPES_HPP_

--- a/include/polka/util/log_format.hpp
+++ b/include/polka/util/log_format.hpp
@@ -8,14 +8,15 @@
 
 #pragma once
 
-namespace polka {
+namespace polka
+{
 
 // Standard throttle windows (milliseconds) for RCLCPP_*_THROTTLE.
 //   fast   — per-message validation (e.g. non-finite IMU values)
 //   normal — steady-state degradation (e.g. stale source, TF failing)
 //   slow   — persistent suppressed state
-constexpr int kLogThrottleFastMs   = 1000;
+constexpr int kLogThrottleFastMs = 1000;
 constexpr int kLogThrottleNormalMs = 5000;
-constexpr int kLogThrottleSlowMs   = 30000;
+constexpr int kLogThrottleSlowMs = 30000;
 
 }  // namespace polka

--- a/include/polka/util/qos_builder.hpp
+++ b/include/polka/util/qos_builder.hpp
@@ -15,43 +15,50 @@
 #ifndef POLKA__UTIL__QOS_BUILDER_HPP_
 #define POLKA__UTIL__QOS_BUILDER_HPP_
 
-#include "polka/types.hpp"
-
-#include <rclcpp/rclcpp.hpp>
 #include <chrono>
 
-namespace polka {
+#include "polka/types.hpp"
+#include <rclcpp/rclcpp.hpp>
+
+namespace polka
+{
 
 inline rclcpp::QoS build_qos(const OutputQosConfig & cfg)
 {
   rclcpp::QoS qos(cfg.history_depth);
 
-  if (cfg.reliability == "best_effort")
+  if (cfg.reliability == "best_effort") {
     qos.reliability(rclcpp::ReliabilityPolicy::BestEffort);
-  else
+  } else {
     qos.reliability(rclcpp::ReliabilityPolicy::Reliable);
+  }
 
-  if (cfg.durability == "transient_local")
+  if (cfg.durability == "transient_local") {
     qos.durability(rclcpp::DurabilityPolicy::TransientLocal);
-  else
+  } else {
     qos.durability(rclcpp::DurabilityPolicy::Volatile);
+  }
 
-  if (cfg.liveliness == "manual_by_topic")
+  if (cfg.liveliness == "manual_by_topic") {
     qos.liveliness(rclcpp::LivelinessPolicy::ManualByTopic);
-  else
+  } else {
     qos.liveliness(rclcpp::LivelinessPolicy::Automatic);
+  }
 
-  if (cfg.liveliness_lease_duration_ms > 0.0)
+  if (cfg.liveliness_lease_duration_ms > 0.0) {
     qos.liveliness_lease_duration(
       std::chrono::milliseconds(static_cast<int64_t>(cfg.liveliness_lease_duration_ms)));
+  }
 
-  if (cfg.deadline_ms > 0.0)
+  if (cfg.deadline_ms > 0.0) {
     qos.deadline(
       std::chrono::milliseconds(static_cast<int64_t>(cfg.deadline_ms)));
+  }
 
-  if (cfg.lifespan_ms > 0.0)
+  if (cfg.lifespan_ms > 0.0) {
     qos.lifespan(
       std::chrono::milliseconds(static_cast<int64_t>(cfg.lifespan_ms)));
+  }
 
   return qos;
 }

--- a/include/polka/util/se3_exp.hpp
+++ b/include/polka/util/se3_exp.hpp
@@ -70,7 +70,12 @@ inline Eigen::Isometry3d se3_exp(const Eigen::Vector3d & rho,
   }
 
   T.linear() = Eigen::AngleAxisd(theta, phi / theta).toRotationMatrix();
-  T.translation() = so3_left_jacobian(phi) * rho;
+  // V * 0 == 0 regardless of V, so skip the left Jacobian (norm, hat, two
+  // trig evaluations, matrix square) whenever there's no translation to
+  // apply — the common case when gravity can't be subtracted (no IMU
+  // orientation) and deskewing falls back to rotation-only.
+  if (rho.squaredNorm() > 0.0)
+    T.translation() = so3_left_jacobian(phi) * rho;
   return T;
 }
 

--- a/include/polka/util/se3_exp.hpp
+++ b/include/polka/util/se3_exp.hpp
@@ -24,15 +24,16 @@
 #include <Eigen/Geometry>
 #include <cmath>
 
-namespace polka {
+namespace polka
+{
 
 /// Skew-symmetric matrix [v]_x such that [v]_x * w = v x w.
 inline Eigen::Matrix3d hat(const Eigen::Vector3d & v)
 {
   Eigen::Matrix3d m;
-  m <<     0, -v.z(),  v.y(),
-       v.z(),      0, -v.x(),
-      -v.y(),  v.x(),      0;
+  m << 0, -v.z(), v.y(),
+    v.z(), 0, -v.x(),
+    -v.y(), v.x(), 0;
   return m;
 }
 
@@ -44,8 +45,9 @@ inline Eigen::Matrix3d so3_left_jacobian(const Eigen::Vector3d & phi)
   double theta = phi.norm();
   Eigen::Matrix3d Phi = hat(phi);
 
-  if (theta < 1e-10)
+  if (theta < 1e-10) {
     return Eigen::Matrix3d::Identity() + 0.5 * Phi;
+  }
 
   double theta2 = theta * theta;
   double a = (1.0 - std::cos(theta)) / theta2;
@@ -58,8 +60,9 @@ inline Eigen::Matrix3d so3_left_jacobian(const Eigen::Vector3d & phi)
 ///   ρ: translational component
 ///   φ: rotational component (axis-angle, ‖φ‖ = rotation angle)
 /// Returns T such that T.translation() = V * ρ and T.rotation() = exp(φ).
-inline Eigen::Isometry3d se3_exp(const Eigen::Vector3d & rho,
-                                 const Eigen::Vector3d & phi)
+inline Eigen::Isometry3d se3_exp(
+  const Eigen::Vector3d & rho,
+  const Eigen::Vector3d & phi)
 {
   Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
   double theta = phi.norm();
@@ -74,8 +77,9 @@ inline Eigen::Isometry3d se3_exp(const Eigen::Vector3d & rho,
   // trig evaluations, matrix square) whenever there's no translation to
   // apply — the common case when gravity can't be subtracted (no IMU
   // orientation) and deskewing falls back to rotation-only.
-  if (rho.squaredNorm() > 0.0)
+  if (rho.squaredNorm() > 0.0) {
     T.translation() = so3_left_jacobian(phi) * rho;
+  }
   return T;
 }
 

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -16,7 +16,8 @@
 #include <stdexcept>
 #include <cmath>
 
-namespace polka {
+namespace polka
+{
 
 ConfigLoader::ConfigLoader(rclcpp::Node * node)
 : node_(node), logger_(node->get_logger())
@@ -62,7 +63,9 @@ void ConfigLoader::declare_defaults()
   node_->declare_parameter<double>("outputs.cloud.filters.range.max", 30.0);
   node_->declare_parameter<bool>("outputs.cloud.filters.angular.enabled", false);
   node_->declare_parameter<bool>("outputs.cloud.filters.angular.invert", false);
-  node_->declare_parameter<std::vector<double>>("outputs.cloud.filters.angular.ranges", {0.0, 360.0});
+  node_->declare_parameter<std::vector<double>>(
+    "outputs.cloud.filters.angular.ranges",
+    {0.0, 360.0});
   node_->declare_parameter<bool>("outputs.cloud.filters.box.enabled", false);
   node_->declare_parameter<double>("outputs.cloud.filters.box.x_min", -20.0);
   node_->declare_parameter<double>("outputs.cloud.filters.box.x_max", 20.0);
@@ -137,8 +140,8 @@ FilterParams ConfigLoader::load_filter_params(const std::string & prefix)
   for (size_t i = 0; i + 1 < ang_flat.size(); i += 2) {
     double lo = std::fmod(ang_flat[i], 360.0);
     double hi = std::fmod(ang_flat[i + 1], 360.0);
-    if (lo < 0.0) lo += 360.0;
-    if (hi < 0.0) hi += 360.0;
+    if (lo < 0.0) {lo += 360.0;}
+    if (hi < 0.0) {hi += 360.0;}
     fp.angular_ranges.emplace_back(lo, hi);
   }
 
@@ -166,17 +169,23 @@ MergeConfig ConfigLoader::read_common_params()
   cfg.max_source_spread_warn = node_->get_parameter("max_source_spread_warn").as_double();
 
   auto ts_str = node_->get_parameter("timestamp_strategy").as_string();
-  if (ts_str == "earliest") cfg.timestamp_strategy = TimestampStrategy::EARLIEST;
-  else if (ts_str == "latest") cfg.timestamp_strategy = TimestampStrategy::LATEST;
-  else if (ts_str == "average") cfg.timestamp_strategy = TimestampStrategy::AVERAGE;
-  else if (ts_str == "local") cfg.timestamp_strategy = TimestampStrategy::LOCAL;
-  else throw std::runtime_error("polka: invalid timestamp_strategy '" + ts_str + "'");
+  if (ts_str == "earliest") {
+    cfg.timestamp_strategy = TimestampStrategy::EARLIEST;
+  } else if (ts_str == "latest") {
+    cfg.timestamp_strategy = TimestampStrategy::LATEST;
+  } else if (ts_str == "average") {
+    cfg.timestamp_strategy = TimestampStrategy::AVERAGE;
+  } else if (ts_str == "local") {cfg.timestamp_strategy = TimestampStrategy::LOCAL;} else {
+    throw std::runtime_error("polka: invalid timestamp_strategy '" + ts_str + "'");
+  }
 
   cfg.point_timestamps.enabled = node_->get_parameter("point_timestamps.enabled").as_bool();
   auto ppt_mode = node_->get_parameter("point_timestamps.mode").as_string();
-  if (ppt_mode == "offset") cfg.point_timestamps.mode = PerPointTimeMode::OFFSET;
-  else if (ppt_mode == "absolute") cfg.point_timestamps.mode = PerPointTimeMode::ABSOLUTE;
-  else throw std::runtime_error("polka: invalid point_timestamps.mode '" + ppt_mode + "'");
+  if (ppt_mode == "offset") {
+    cfg.point_timestamps.mode = PerPointTimeMode::OFFSET;
+  } else if (ppt_mode == "absolute") {
+    cfg.point_timestamps.mode = PerPointTimeMode::ABSOLUTE;
+  } else {throw std::runtime_error("polka: invalid point_timestamps.mode '" + ppt_mode + "'");}
   cfg.suppress_duplicate_timestamps =
     node_->get_parameter("suppress_duplicate_timestamps").as_bool();
 
@@ -205,8 +214,9 @@ MergeConfig ConfigLoader::read_common_params()
     double lx = node_->get_parameter("outputs.cloud.voxel.leaf_x").as_double();
     double ly = node_->get_parameter("outputs.cloud.voxel.leaf_y").as_double();
     double lz = node_->get_parameter("outputs.cloud.voxel.leaf_z").as_double();
-    if (uniform > 0.0 && lx == 0.0 && ly == 0.0 && lz == 0.0)
+    if (uniform > 0.0 && lx == 0.0 && ly == 0.0 && lz == 0.0) {
       lx = ly = lz = uniform;
+    }
     cfg.cloud_output.voxel.leaf_x = static_cast<float>(lx);
     cfg.cloud_output.voxel.leaf_y = static_cast<float>(ly);
     cfg.cloud_output.voxel.leaf_z = static_cast<float>(lz);
@@ -229,7 +239,8 @@ MergeConfig ConfigLoader::read_common_params()
   cfg.scan_output.flatten.z_max = node_->get_parameter("outputs.scan.z_max").as_double();
   cfg.scan_output.flatten.angle_min = node_->get_parameter("outputs.scan.angle_min").as_double();
   cfg.scan_output.flatten.angle_max = node_->get_parameter("outputs.scan.angle_max").as_double();
-  cfg.scan_output.flatten.angle_increment = node_->get_parameter("outputs.scan.angle_increment").as_double();
+  cfg.scan_output.flatten.angle_increment =
+    node_->get_parameter("outputs.scan.angle_increment").as_double();
   cfg.scan_output.flatten.range_min = node_->get_parameter("outputs.scan.range_min").as_double();
   cfg.scan_output.flatten.range_max = node_->get_parameter("outputs.scan.range_max").as_double();
   cfg.scan_output.flatten.compute_bins();
@@ -328,7 +339,7 @@ SelfFilterConfig ConfigLoader::load_self_filter_config(const std::string & prefi
 {
   SelfFilterConfig sf;
   sf.enabled = node_->get_parameter(prefix + ".enabled").as_bool();
-  if (!sf.enabled) return sf;
+  if (!sf.enabled) {return sf;}
 
   auto box_names = node_->get_parameter(prefix + ".box_names").as_string_array();
   for (const auto & name : box_names) {
@@ -355,24 +366,31 @@ SelfFilterConfig ConfigLoader::load_self_filter_config(const std::string & prefi
 
 void ConfigLoader::validate(const MergeConfig & config)
 {
-  if (config.sources.empty())
+  if (config.sources.empty()) {
     throw std::runtime_error("polka: source_names is empty");
-  if (config.output_rate <= 0.0 && config.output_rate != -1.0)
+  }
+  if (config.output_rate <= 0.0 && config.output_rate != -1.0) {
     throw std::runtime_error("polka: output_rate must be > 0 or -1 (adaptive)");
-  if (config.source_timeout <= 0.0)
+  }
+  if (config.source_timeout <= 0.0) {
     throw std::runtime_error("polka: source_timeout must be > 0");
-  if (!config.cloud_output.enabled && !config.scan_output.enabled)
+  }
+  if (!config.cloud_output.enabled && !config.scan_output.enabled) {
     throw std::runtime_error("polka: at least one output (cloud or scan) must be enabled");
+  }
   if (config.cloud_output.voxel.enabled) {
     if (config.cloud_output.voxel.leaf_x <= 0.0f ||
-        config.cloud_output.voxel.leaf_y <= 0.0f ||
-        config.cloud_output.voxel.leaf_z <= 0.0f)
+      config.cloud_output.voxel.leaf_y <= 0.0f ||
+      config.cloud_output.voxel.leaf_z <= 0.0f)
+    {
       throw std::runtime_error(
-        "polka: voxel filter enabled but leaf size is <= 0 (would crash pcl::VoxelGrid)");
+              "polka: voxel filter enabled but leaf size is <= 0 (would crash pcl::VoxelGrid)");
+    }
   }
   for (const auto & src : config.sources) {
-    if (src.topic.empty())
+    if (src.topic.empty()) {
       throw std::runtime_error("polka: source '" + src.name + "' has empty topic");
+    }
   }
 }
 

--- a/src/filters/angular_filter.cpp
+++ b/src/filters/angular_filter.cpp
@@ -15,7 +15,8 @@
 #include "polka/filters/angular_filter.hpp"
 #include <cmath>
 
-namespace polka {
+namespace polka
+{
 
 AngularFilter::AngularFilter(
   const std::vector<std::pair<double, double>> & ranges_deg, bool invert)
@@ -27,9 +28,9 @@ bool AngularFilter::in_ranges(double angle_deg) const
 {
   for (const auto & r : ranges_deg_) {
     if (r.first <= r.second) {
-      if (angle_deg >= r.first && angle_deg <= r.second) return true;
+      if (angle_deg >= r.first && angle_deg <= r.second) {return true;}
     } else {
-      if (angle_deg >= r.first || angle_deg <= r.second) return true;
+      if (angle_deg >= r.first || angle_deg <= r.second) {return true;}
     }
   }
   return false;
@@ -42,7 +43,7 @@ void AngularFilter::apply(CloudT & cloud, const std::string & /*frame_id*/)
     const auto & p = cloud[i];
     double angle_rad = std::atan2(static_cast<double>(p.y), static_cast<double>(p.x));
     double angle_deg = angle_rad * 180.0 / M_PI;
-    if (angle_deg < 0.0) angle_deg += 360.0;
+    if (angle_deg < 0.0) {angle_deg += 360.0;}
 
     bool match = in_ranges(angle_deg);
     bool keep = invert_ ? !match : match;

--- a/src/filters/box_filter.cpp
+++ b/src/filters/box_filter.cpp
@@ -14,10 +14,12 @@
 
 #include "polka/filters/box_filter.hpp"
 
-namespace polka {
+namespace polka
+{
 
-BoxFilter::BoxFilter(const Eigen::Vector3d & box_min, const Eigen::Vector3d & box_max,
-                     bool invert)
+BoxFilter::BoxFilter(
+  const Eigen::Vector3d & box_min, const Eigen::Vector3d & box_max,
+  bool invert)
 : bx_min_(static_cast<float>(box_min.x())), bx_max_(static_cast<float>(box_max.x())),
   by_min_(static_cast<float>(box_min.y())), by_max_(static_cast<float>(box_max.y())),
   bz_min_(static_cast<float>(box_min.z())), bz_max_(static_cast<float>(box_max.z())),
@@ -31,8 +33,8 @@ void BoxFilter::apply(CloudT & cloud, const std::string & /*frame_id*/)
   for (size_t i = 0; i < cloud.size(); ++i) {
     const auto & p = cloud[i];
     bool inside = p.x >= bx_min_ && p.x <= bx_max_ &&
-                  p.y >= by_min_ && p.y <= by_max_ &&
-                  p.z >= bz_min_ && p.z <= bz_max_;
+      p.y >= by_min_ && p.y <= by_max_ &&
+      p.z >= bz_min_ && p.z <= bz_max_;
     if (inside != invert_) {
       cloud[j++] = p;
     }

--- a/src/filters/range_filter.cpp
+++ b/src/filters/range_filter.cpp
@@ -14,7 +14,8 @@
 
 #include "polka/filters/range_filter.hpp"
 
-namespace polka {
+namespace polka
+{
 
 RangeFilter::RangeFilter(double min_range, double max_range)
 : min_range_sq_(static_cast<float>(min_range * min_range)),

--- a/src/imu_buffer.cpp
+++ b/src/imu_buffer.cpp
@@ -13,11 +13,15 @@
 // limitations under the License.
 
 #include "polka/input/imu_buffer.hpp"
-#include "polka/util/log_format.hpp"
+
 #include <Eigen/Geometry>
+
 #include <cmath>
 
-namespace polka {
+#include "polka/util/log_format.hpp"
+
+namespace polka
+{
 
 ImuBuffer::ImuBuffer(rclcpp::Node * node, const std::string & topic, int buffer_size)
 : max_size_(buffer_size), logger_(node->get_logger()), clock_(node->get_clock())
@@ -25,7 +29,8 @@ ImuBuffer::ImuBuffer(rclcpp::Node * node, const std::string & topic, int buffer_
   sub_ = node->create_subscription<sensor_msgs::msg::Imu>(
     topic, rclcpp::SensorDataQoS(),
     std::bind(&ImuBuffer::callback, this, std::placeholders::_1));
-  RCLCPP_INFO(logger_, "polka: IMU buffer subscribing to '%s' (capacity %d)",
+  RCLCPP_INFO(
+    logger_, "polka: IMU buffer subscribing to '%s' (capacity %d)",
     topic.c_str(), buffer_size);
 }
 
@@ -39,8 +44,10 @@ void ImuBuffer::callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
   const auto & a = msg->linear_acceleration;
   const auto & w = msg->angular_velocity;
   if (!std::isfinite(a.x) || !std::isfinite(a.y) || !std::isfinite(a.z) ||
-      !std::isfinite(w.x) || !std::isfinite(w.y) || !std::isfinite(w.z)) {
-    RCLCPP_WARN_THROTTLE(logger_, *clock_, kLogThrottleFastMs,
+    !std::isfinite(w.x) || !std::isfinite(w.y) || !std::isfinite(w.z))
+  {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, kLogThrottleFastMs,
       "polka: IMU buffer received non-finite values, ignoring");
     return;
   }
@@ -57,12 +64,14 @@ void ImuBuffer::callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
       accel -= g_imu;
     } else {
       accel.setZero();
-      RCLCPP_WARN_THROTTLE(logger_, *clock_, kLogThrottleNormalMs,
+      RCLCPP_WARN_THROTTLE(
+        logger_, *clock_, kLogThrottleNormalMs,
         "polka: IMU has degenerate orientation quaternion, translation deskew disabled");
     }
   } else {
     accel.setZero();
-    RCLCPP_WARN_ONCE(logger_,
+    RCLCPP_WARN_ONCE(
+      logger_,
       "polka: IMU has no orientation — cannot subtract gravity, "
       "translation deskew disabled (rotation-only)");
   }
@@ -75,8 +84,9 @@ void ImuBuffer::callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
   {
     std::lock_guard<std::mutex> lock(mutex_);
     buffer_.push_back(sample);
-    while (static_cast<int>(buffer_.size()) > max_size_)
+    while (static_cast<int>(buffer_.size()) > max_size_) {
       buffer_.pop_front();
+    }
   }
 
   auto avg = std::make_shared<AveragedImu>();

--- a/src/merge_engine/cpu_merge_engine.cpp
+++ b/src/merge_engine/cpu_merge_engine.cpp
@@ -15,14 +15,16 @@
 #include "polka/merge_engine/cpu_merge_engine.hpp"
 #include <cmath>
 
-namespace polka {
+namespace polka
+{
 
 CloudT::Ptr CpuMergeEngine::merge(const std::vector<MergeInput> & sources)
 {
   auto output = std::make_shared<CloudT>();
   size_t total = 0;
-  for (const auto & src : sources)
+  for (const auto & src : sources) {
     total += src.cloud->size();
+  }
   output->resize(total);
 
   size_t out_idx = 0;
@@ -30,8 +32,9 @@ CloudT::Ptr CpuMergeEngine::merge(const std::vector<MergeInput> & sources)
     Eigen::Affine3f tf = src.transform.cast<float>();
     for (size_t i = 0; i < src.cloud->size(); ++i) {
       const auto & p = (*src.cloud)[i];
-      if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z))
+      if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {
         continue;
+      }
       auto & o = (*output)[out_idx++];
       Eigen::Vector3f out = tf * Eigen::Vector3f(p.x, p.y, p.z);
       o.x = out.x();

--- a/src/output/output_pipeline.cpp
+++ b/src/output/output_pipeline.cpp
@@ -13,16 +13,18 @@
 // limitations under the License.
 
 #include "polka/output/output_pipeline.hpp"
-#include "polka/filters/filter_chain.hpp"
-#include "polka/filters/box_filter.hpp"
 
 #include <pcl/filters/voxel_grid.h>
+
+#include "polka/filters/filter_chain.hpp"
+#include "polka/filters/box_filter.hpp"
 // PointXYZIT is a custom point type, so VoxelGrid/PCLBase are not pre-instantiated
 // in libpcl; pull in the template implementations to instantiate them here.
 #include <pcl/impl/pcl_base.hpp>
 #include <pcl/filters/impl/voxel_grid.hpp>
 
-namespace polka {
+namespace polka
+{
 
 void OutputPipeline::configure(const CloudOutputConfig & cfg)
 {
@@ -39,23 +41,26 @@ void OutputPipeline::build_filters()
 {
   filters_ = build_filter_chain(config_.filters);
   if (config_.self_filter.enabled) {
-    for (const auto & eb : config_.self_filter.boxes)
+    for (const auto & eb : config_.self_filter.boxes) {
       filters_.push_back(std::make_unique<BoxFilter>(eb.min, eb.max, true));
+    }
   }
 }
 
 void OutputPipeline::process(CloudT & cloud, const std::string & frame_id) const
 {
-  for (const auto & filter : filters_)
+  for (const auto & filter : filters_) {
     filter->apply(cloud, frame_id);
+  }
 
   if (config_.height_cap.enabled) {
     const float z_min = static_cast<float>(config_.height_cap.z_min);
     const float z_max = static_cast<float>(config_.height_cap.z_max);
     size_t j = 0;
     for (size_t i = 0; i < cloud.size(); ++i) {
-      if (cloud[i].z >= z_min && cloud[i].z <= z_max)
+      if (cloud[i].z >= z_min && cloud[i].z <= z_max) {
         cloud[j++] = cloud[i];
+      }
     }
     cloud.resize(j);
     cloud.width = static_cast<uint32_t>(j);
@@ -83,8 +88,9 @@ PipelineConfig OutputPipeline::to_pipeline_config(
   pcfg.height_cap = config_.height_cap;
   pcfg.voxel = config_.voxel;
   pcfg.scan_enabled = scan_enabled;
-  if (scan_enabled)
+  if (scan_enabled) {
     pcfg.flatten = flatten;
+  }
   return pcfg;
 }
 

--- a/src/output/scan_builder.cpp
+++ b/src/output/scan_builder.cpp
@@ -17,7 +17,8 @@
 #include <cmath>
 #include <limits>
 
-namespace polka {
+namespace polka
+{
 
 void ScanBuilder::configure(
   const ScanOutputConfig & cfg, double output_rate, const std::string & frame_id)
@@ -60,13 +61,13 @@ sensor_msgs::msg::LaserScan ScanBuilder::from_cloud(
   scan.ranges.assign(n, std::numeric_limits<float>::infinity());
 
   for (const auto & p : *cloud) {
-    if (p.z < z_min || p.z > z_max) continue;
+    if (p.z < z_min || p.z > z_max) {continue;}
     float az = std::atan2(p.y, p.x);
-    if (az < a_min || az > a_max) continue;
+    if (az < a_min || az > a_max) {continue;}
     int bin = static_cast<int>((az - a_min) / a_inc);
-    if (bin < 0 || bin >= n) continue;
+    if (bin < 0 || bin >= n) {continue;}
     float range = std::sqrt(p.x * p.x + p.y * p.y);
-    if (range < r_min || range > r_max) continue;
+    if (range < r_min || range > r_max) {continue;}
     scan.ranges[bin] = std::min(scan.ranges[bin], range);
   }
   return scan;

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 #include "polka/polka_node.hpp"
-#include "polka/util/log_format.hpp"
-#include "polka/util/qos_builder.hpp"
-#include "polka/util/se3_exp.hpp"
-#include "polka/merge_engine/cpu_merge_engine.hpp"
 
 #include <pcl_conversions/pcl_conversions.h>
 #include <pcl/console/print.h>
 #include <pcl/common/io.h>
-#include <tf2_eigen/tf2_eigen.hpp>
-#include <rcl_interfaces/msg/set_parameters_result.hpp>
+#ifdef POLKA_CUDA_ENABLED
+#include <cuda_runtime.h>
+#endif
 
 #include <algorithm>
 #include <chrono>
@@ -30,12 +27,19 @@
 #include <functional>
 #include <sstream>
 
+#include "polka/util/log_format.hpp"
+#include "polka/util/qos_builder.hpp"
+#include "polka/util/se3_exp.hpp"
+#include "polka/merge_engine/cpu_merge_engine.hpp"
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <rcl_interfaces/msg/set_parameters_result.hpp>
+
 #ifdef POLKA_CUDA_ENABLED
 #include "polka/merge_engine/cuda_merge_engine.hpp"
-#include <cuda_runtime.h>
 #endif
 
-namespace polka {
+namespace polka
+{
 
 PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("polka", options), config_loader_(this)
@@ -58,49 +62,58 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
     if (device_count > 0) {
       merge_engine_ = std::make_unique<CudaMergeEngine>(config_);
     } else {
-      RCLCPP_WARN(get_logger(),
+      RCLCPP_WARN(
+        get_logger(),
         "polka: enable_gpu=true but no CUDA device found, falling back to CPU");
     }
   }
 #endif
-  if (!merge_engine_)
+  if (!merge_engine_) {
     merge_engine_ = std::make_unique<CpuMergeEngine>();
+  }
 
-  if (config_.motion_compensation.enabled && !config_.motion_compensation.imu_topic.empty())
+  if (config_.motion_compensation.enabled && !config_.motion_compensation.imu_topic.empty()) {
     global_imu_ = std::make_shared<ImuBuffer>(
       this, config_.motion_compensation.imu_topic,
       config_.motion_compensation.imu_buffer_size);
-  else if (config_.motion_compensation.enabled)
-    RCLCPP_WARN(get_logger(),
+  } else if (config_.motion_compensation.enabled) {
+    RCLCPP_WARN(
+      get_logger(),
       "polka: motion compensation enabled but imu_topic is empty, deskewing will not activate");
+  }
 
   SourceAdapter::ImuGetter imu_getter = nullptr;
-  if (config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew
-      && global_imu_) {
+  if (config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew &&
+    global_imu_)
+  {
     imu_getter = [this]() -> std::shared_ptr<const AveragedImu> {
-      return global_imu_->snapshot();
-    };
+        return global_imu_->snapshot();
+      };
   }
 
   bool gpu_filters = merge_engine_->is_gpu();
   bool deskew = config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew;
-  for (const auto & src_cfg : config_.sources)
-    sources_.push_back(std::make_unique<SourceAdapter>(
-      this, src_cfg, gpu_filters, imu_getter, deskew,
-      config_.motion_compensation.deskew_timestamp_field,
-      tf_buffer_, config_.motion_compensation.imu_buffer_size));
+  for (const auto & src_cfg : config_.sources) {
+    sources_.push_back(
+      std::make_unique<SourceAdapter>(
+        this, src_cfg, gpu_filters, imu_getter, deskew,
+        config_.motion_compensation.deskew_timestamp_field,
+        tf_buffer_, config_.motion_compensation.imu_buffer_size));
+  }
 
   last_good_transforms_.resize(sources_.size(), Eigen::Isometry3d::Identity());
 
   output_pipeline_.configure(config_.cloud_output);
   scan_builder_.configure(config_.scan_output, config_.output_rate, config_.output_frame_id);
 
-  if (config_.cloud_output.enabled)
+  if (config_.cloud_output.enabled) {
     cloud_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
       config_.cloud_output.topic, build_qos(config_.cloud_output.qos));
-  if (config_.scan_output.enabled)
+  }
+  if (config_.scan_output.enabled) {
     scan_pub_ = create_publisher<sensor_msgs::msg::LaserScan>(
       config_.scan_output.topic, build_qos(config_.scan_output.qos));
+  }
 
   if (config_.output_rate > 0.0) {
     auto period = std::chrono::duration<double>(1.0 / config_.output_rate);
@@ -109,8 +122,9 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
       std::bind(&PolkaNode::output_callback, this));
   }
 
-  for (const auto & sc : config_.sources)
+  for (const auto & sc : config_.sources) {
     source_names_.push_back(sc.name);
+  }
 
   log_startup_banner();
 
@@ -124,18 +138,18 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
 
 void PolkaNode::diagnose_clock_health(const rclcpp::Time & now)
 {
-  if (clock_diagnosed_) return;
+  if (clock_diagnosed_) {return;}
 
   // Newest sensor stamp across sources that have actually received data. Without any
   // data there is nothing to compare the clock against, so we can't judge yet.
   rclcpp::Time newest;
   bool any = false;
   for (const auto & src : sources_) {
-    if (!src->received()) continue;
+    if (!src->received()) {continue;}
     auto stamp = src->last_stamp();
-    if (!any || stamp > newest) { newest = stamp; any = true; }
+    if (!any || stamp > newest) {newest = stamp; any = true;}
   }
-  if (!any) return;
+  if (!any) {return;}
 
   const double dt = (now - newest).seconds();
   const bool sim = this->get_parameter("use_sim_time").as_bool();
@@ -143,18 +157,20 @@ void PolkaNode::diagnose_clock_health(const rclcpp::Time & now)
   // Allow normal jitter (and the correct --clock case): only react when the clock and
   // the data disagree by several staleness windows.
   const double mismatch = std::max(2.0, config_.source_timeout * 4.0);
-  if (std::fabs(dt) < mismatch) return;
+  if (std::fabs(dt) < mismatch) {return;}
 
   if (sim && count_publishers("/clock") == 0) {
     // Sim time requested but nothing drives /clock, so the clock is frozen near zero.
-    RCLCPP_WARN(get_logger(),
+    RCLCPP_WARN(
+      get_logger(),
       "polka: use_sim_time=true but no publisher on /clock was found — the simulated "
       "clock is not advancing, so timestamp/staleness checks are unreliable. If you are "
       "replaying a rosbag, play it with the --clock flag: ros2 bag play <bag> --clock");
     clock_diagnosed_ = true;
   } else if (!sim && dt > mismatch) {
     // Wall clock vs historical bag stamps: every source will be dropped as stale.
-    RCLCPP_WARN(get_logger(),
+    RCLCPP_WARN(
+      get_logger(),
       "polka: sensor timestamps are %.1f s behind the system clock. This looks like "
       "rosbag replay without simulated time; all sources will be dropped as stale and "
       "no merged cloud will be published. Set use_sim_time:=true and replay with the "
@@ -165,7 +181,8 @@ void PolkaNode::diagnose_clock_health(const rclcpp::Time & now)
   // leave clock_diagnosed_ unset and re-evaluate on the next tick — no false alarm.
 }
 
-namespace {
+namespace
+{
 constexpr uint64_t kMergePerfLogInterval = 50;
 }
 
@@ -174,7 +191,8 @@ void PolkaNode::log_merge_perf(double us, const char * engine_label)
   merge_total_us_ += us;
   merge_max_us_ = std::max(merge_max_us_, us);
   if (++merge_calls_ % kMergePerfLogInterval == 0) {
-    RCLCPP_INFO(get_logger(),
+    RCLCPP_INFO(
+      get_logger(),
       "polka: perf merge [%s]: mean=%.3fms max=%.3fms (over %zu calls)",
       engine_label, merge_total_us_ / kMergePerfLogInterval / 1000.0,
       merge_max_us_ / 1000.0, static_cast<size_t>(kMergePerfLogInterval));
@@ -188,7 +206,8 @@ void PolkaNode::output_callback()
   auto now = this->now();
   diagnose_clock_health(now);
 
-  struct SourceData {
+  struct SourceData
+  {
     CloudT::ConstPtr cloud;
     Eigen::Isometry3d transform;
     FilterParams filter_params;
@@ -199,10 +218,11 @@ void PolkaNode::output_callback()
   for (size_t i = 0; i < sources_.size(); ++i) {
     auto & src = sources_[i];
     auto cloud = src->get_latest();
-    if (!cloud || cloud->empty()) continue;
+    if (!cloud || cloud->empty()) {continue;}
 
     if (src->is_stale(config_.source_timeout, now)) {
-      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleNormalMs,
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), kLogThrottleNormalMs,
         "polka: source '%s' is stale", src->name().c_str());
       continue;
     }
@@ -214,7 +234,8 @@ void PolkaNode::output_callback()
       transform = tf2::transformToEigen(tf_msg.transform);
       last_good_transforms_[i] = transform;
     } catch (const tf2::TransformException & ex) {
-      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleNormalMs,
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), kLogThrottleNormalMs,
         "polka: TF failed for '%s': %s — using last known good transform",
         src->name().c_str(), ex.what());
       transform = last_good_transforms_[i];
@@ -228,7 +249,7 @@ void PolkaNode::output_callback()
     // nothing rather than re-publishing the last cloud with its original stamp: a
     // duplicate header.stamp hands downstream SLAM (e.g. GLIM) two scans with zero
     // IMU samples between them and stalls odometry. A genuine gap is safe to skip.
-    if (config_.suppress_duplicate_timestamps) return;
+    if (config_.suppress_duplicate_timestamps) {return;}
     std::lock_guard<std::mutex> lock(last_data_mutex_);
     if (last_cloud_ && !last_cloud_->empty()) {
       if (cloud_pub_) {
@@ -238,9 +259,9 @@ void PolkaNode::output_callback()
         cloud_pub_->publish(msg);
       }
       if (scan_pub_) {
-        auto scan = last_scan_ranges_.empty()
-          ? scan_builder_.from_cloud(last_cloud_, last_cloud_stamp_)
-          : scan_builder_.from_ranges(last_scan_ranges_, last_cloud_stamp_);
+        auto scan = last_scan_ranges_.empty() ?
+          scan_builder_.from_cloud(last_cloud_, last_cloud_stamp_) :
+          scan_builder_.from_ranges(last_scan_ranges_, last_cloud_stamp_);
         scan_pub_->publish(scan);
       }
     }
@@ -249,15 +270,18 @@ void PolkaNode::output_callback()
 
   std::vector<rclcpp::Time> stamps;
   stamps.reserve(source_data.size());
-  for (const auto & sd : source_data)
+  for (const auto & sd : source_data) {
     stamps.push_back(sd.stamp);
+  }
 
   if (stamps.size() > 1) {
     auto [mn, mx] = std::minmax_element(stamps.begin(), stamps.end());
     double spread = (*mx - *mn).seconds();
-    if (spread > config_.max_source_spread_warn)
-      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleNormalMs,
+    if (spread > config_.max_source_spread_warn) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), kLogThrottleNormalMs,
         "polka: source spread %6.3f s > %6.3f s", spread, config_.max_source_spread_warn);
+    }
   }
 
   auto output_stamp = compute_output_stamp(stamps);
@@ -268,7 +292,7 @@ void PolkaNode::output_callback()
   // header.stamp and no IMU between them. Skip until the stamp actually moves.
   if (config_.suppress_duplicate_timestamps) {
     std::lock_guard<std::mutex> lock(last_data_mutex_);
-    if (last_cloud_ && output_stamp == last_cloud_stamp_) return;
+    if (last_cloud_ && output_stamp == last_cloud_stamp_) {return;}
   }
 
   bool do_compensate = false;
@@ -301,14 +325,17 @@ void PolkaNode::output_callback()
       scan_pub_ != nullptr, config_.scan_output.flatten);
     auto merge_t0 = std::chrono::steady_clock::now();
     auto result = merge_engine_->merge_pipeline(inputs, pcfg);
-    log_merge_perf(std::chrono::duration<double, std::micro>(
-      std::chrono::steady_clock::now() - merge_t0).count(), "CUDA");
-    if (!result.cloud || result.cloud->empty()) return;
+    log_merge_perf(
+      std::chrono::duration<double, std::micro>(
+        std::chrono::steady_clock::now() - merge_t0).count(), "CUDA");
+    if (!result.cloud || result.cloud->empty()) {return;}
 
     if (cloud_pub_) {
       if (config_.point_timestamps.enabled &&
-          config_.point_timestamps.mode == PerPointTimeMode::OFFSET)
+        config_.point_timestamps.mode == PerPointTimeMode::OFFSET)
+      {
         rebase_point_time(*result.cloud, output_stamp);
+      }
       auto msg = to_cloud_msg(*result.cloud);
       msg.header.frame_id = config_.output_frame_id;
       msg.header.stamp = output_stamp;
@@ -318,9 +345,9 @@ void PolkaNode::output_callback()
       last_cloud_stamp_ = output_stamp;
     }
     if (scan_pub_) {
-      auto scan = result.scan_ranges.empty()
-        ? scan_builder_.from_cloud(result.cloud, output_stamp)
-        : scan_builder_.from_ranges(result.scan_ranges, output_stamp);
+      auto scan = result.scan_ranges.empty() ?
+        scan_builder_.from_cloud(result.cloud, output_stamp) :
+        scan_builder_.from_ranges(result.scan_ranges, output_stamp);
       scan_pub_->publish(scan);
       std::lock_guard<std::mutex> lock(last_data_mutex_);
       last_scan_ranges_ = result.scan_ranges;
@@ -328,21 +355,26 @@ void PolkaNode::output_callback()
   } else {
     auto merge_t0 = std::chrono::steady_clock::now();
     auto merged = merge_engine_->merge(inputs);
-    log_merge_perf(std::chrono::duration<double, std::micro>(
-      std::chrono::steady_clock::now() - merge_t0).count(), "CPU");
-    if (!merged || merged->empty()) return;
+    log_merge_perf(
+      std::chrono::duration<double, std::micro>(
+        std::chrono::steady_clock::now() - merge_t0).count(), "CPU");
+    if (!merged || merged->empty()) {return;}
 
-    if (config_.point_timestamps.enabled && config_.cloud_output.voxel.enabled)
-      RCLCPP_WARN_ONCE(get_logger(),
+    if (config_.point_timestamps.enabled && config_.cloud_output.voxel.enabled) {
+      RCLCPP_WARN_ONCE(
+        get_logger(),
         "polka: CPU voxel downsampling reduces per-point 'time' precision to float; "
         "use enable_gpu for exact per-point time");
+    }
 
     output_pipeline_.process(*merged, config_.output_frame_id);
 
     if (cloud_pub_) {
       if (config_.point_timestamps.enabled &&
-          config_.point_timestamps.mode == PerPointTimeMode::OFFSET)
+        config_.point_timestamps.mode == PerPointTimeMode::OFFSET)
+      {
         rebase_point_time(*merged, output_stamp);
+      }
       auto msg = to_cloud_msg(*merged);
       msg.header.frame_id = config_.output_frame_id;
       msg.header.stamp = output_stamp;
@@ -362,7 +394,7 @@ void PolkaNode::output_callback()
 
 rclcpp::Time PolkaNode::compute_output_stamp(const std::vector<rclcpp::Time> & stamps)
 {
-  if (stamps.empty()) return this->now();
+  if (stamps.empty()) {return this->now();}
   switch (config_.timestamp_strategy) {
     case TimestampStrategy::EARLIEST:
       return *std::min_element(stamps.begin(), stamps.end());
@@ -371,10 +403,12 @@ rclcpp::Time PolkaNode::compute_output_stamp(const std::vector<rclcpp::Time> & s
     case TimestampStrategy::LOCAL:
       return this->now();
     case TimestampStrategy::AVERAGE: {
-      double sum = 0.0;
-      for (const auto & s : stamps) sum += s.seconds();
-      return rclcpp::Time(static_cast<int64_t>((sum / stamps.size()) * 1e9));
-    }
+        double sum = 0.0;
+        for (const auto & s : stamps) {
+          sum += s.seconds();
+        }
+        return rclcpp::Time(static_cast<int64_t>((sum / stamps.size()) * 1e9));
+      }
     default:
       return this->now();
   }
@@ -386,8 +420,9 @@ void PolkaNode::rebase_point_time(CloudT & cloud, const rclcpp::Time & stamp)
   // a per-point offset relative to the cloud header. Subtracting in double keeps
   // ~sub-microsecond precision even though the absolute values are ~1.7e9.
   const double base = stamp.seconds();
-  for (auto & p : cloud)
+  for (auto & p : cloud) {
     p.time -= base;
+  }
 }
 
 sensor_msgs::msg::PointCloud2 PolkaNode::to_cloud_msg(const CloudT & cloud) const
@@ -430,21 +465,23 @@ bool PolkaNode::reconfigure()
     changes.emplace_back(buf);
   }
 
-  if (config_.cloud_output.enabled && !prev_cloud_enabled)
+  if (config_.cloud_output.enabled && !prev_cloud_enabled) {
     cloud_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
       config_.cloud_output.topic, build_qos(config_.cloud_output.qos));
-  else if (!config_.cloud_output.enabled && prev_cloud_enabled)
+  } else if (!config_.cloud_output.enabled && prev_cloud_enabled) {
     cloud_pub_.reset();
+  }
 
-  if (config_.scan_output.enabled && !prev_scan_enabled)
+  if (config_.scan_output.enabled && !prev_scan_enabled) {
     scan_pub_ = create_publisher<sensor_msgs::msg::LaserScan>(
       config_.scan_output.topic, build_qos(config_.scan_output.qos));
-  else if (!config_.scan_output.enabled && prev_scan_enabled)
+  } else if (!config_.scan_output.enabled && prev_scan_enabled) {
     scan_pub_.reset();
+  }
 
   bool imu_was_enabled = (global_imu_ != nullptr);
-  bool imu_now_enabled = config_.motion_compensation.enabled
-                         && !config_.motion_compensation.imu_topic.empty();
+  bool imu_now_enabled = config_.motion_compensation.enabled &&
+    !config_.motion_compensation.imu_topic.empty();
   if (imu_now_enabled && !imu_was_enabled) {
     global_imu_ = std::make_shared<ImuBuffer>(
       this, config_.motion_compensation.imu_topic,
@@ -455,25 +492,28 @@ bool PolkaNode::reconfigure()
     changes.emplace_back("motion_compensation=off");
   }
 
-  if (config_.cloud_output.enabled != prev_cloud_enabled)
+  if (config_.cloud_output.enabled != prev_cloud_enabled) {
     changes.emplace_back(
       std::string("cloud_output=") + (config_.cloud_output.enabled ? "on" : "off"));
-  if (config_.scan_output.enabled != prev_scan_enabled)
+  }
+  if (config_.scan_output.enabled != prev_scan_enabled) {
     changes.emplace_back(
       std::string("scan_output=") + (config_.scan_output.enabled ? "on" : "off"));
+  }
 
   output_pipeline_.configure(config_.cloud_output);
   scan_builder_.configure(config_.scan_output, config_.output_rate, config_.output_frame_id);
 
-  for (size_t i = 0; i < sources_.size() && i < config_.sources.size(); ++i)
+  for (size_t i = 0; i < sources_.size() && i < config_.sources.size(); ++i) {
     sources_[i]->rebuild_filters(config_.sources[i].filter_params);
+  }
 
   if (changes.empty()) {
     RCLCPP_INFO(get_logger(), "polka: reconfigured (filters only)");
   } else {
     std::string joined;
     for (size_t i = 0; i < changes.size(); ++i) {
-      if (i) joined += ", ";
+      if (i) {joined += ", ";}
       joined += changes[i];
     }
     RCLCPP_INFO(get_logger(), "polka: reconfigured — %s", joined.c_str());
@@ -510,8 +550,8 @@ void PolkaNode::log_startup_banner() const
       (sc.type == SourceType::POINTCLOUD2) ? "pointcloud2" : "laserscan  ";
     const auto & fp = sc.filter_params;
     int nfilters = (fp.range_filter_enabled ? 1 : 0) +
-                   (fp.angular_filter_enabled ? 1 : 0) +
-                   (fp.box_filter_enabled ? 1 : 0);
+      (fp.angular_filter_enabled ? 1 : 0) +
+      (fp.box_filter_enabled ? 1 : 0);
     os << "polka:     " << sc.name
        << "  " << type_str
        << "  '" << sc.topic << "'"

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -175,9 +175,9 @@ void PolkaNode::log_merge_perf(double us, const char * engine_label)
   merge_max_us_ = std::max(merge_max_us_, us);
   if (++merge_calls_ % kMergePerfLogInterval == 0) {
     RCLCPP_INFO(get_logger(),
-      "polka: perf merge [%s]: mean=%.3fms max=%.3fms (over %llu calls)",
+      "polka: perf merge [%s]: mean=%.3fms max=%.3fms (over %zu calls)",
       engine_label, merge_total_us_ / kMergePerfLogInterval / 1000.0,
-      merge_max_us_ / 1000.0, static_cast<unsigned long long>(kMergePerfLogInterval));
+      merge_max_us_ / 1000.0, static_cast<size_t>(kMergePerfLogInterval));
     merge_total_us_ = 0.0;
     merge_max_us_ = 0.0;
   }

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -165,6 +165,24 @@ void PolkaNode::diagnose_clock_health(const rclcpp::Time & now)
   // leave clock_diagnosed_ unset and re-evaluate on the next tick — no false alarm.
 }
 
+namespace {
+constexpr uint64_t kMergePerfLogInterval = 50;
+}
+
+void PolkaNode::log_merge_perf(double us, const char * engine_label)
+{
+  merge_total_us_ += us;
+  merge_max_us_ = std::max(merge_max_us_, us);
+  if (++merge_calls_ % kMergePerfLogInterval == 0) {
+    RCLCPP_INFO(get_logger(),
+      "polka: perf merge [%s]: mean=%.3fms max=%.3fms (over %llu calls)",
+      engine_label, merge_total_us_ / kMergePerfLogInterval / 1000.0,
+      merge_max_us_ / 1000.0, static_cast<unsigned long long>(kMergePerfLogInterval));
+    merge_total_us_ = 0.0;
+    merge_max_us_ = 0.0;
+  }
+}
+
 void PolkaNode::output_callback()
 {
   auto now = this->now();
@@ -281,7 +299,10 @@ void PolkaNode::output_callback()
   if (merge_engine_->is_gpu()) {
     auto pcfg = output_pipeline_.to_pipeline_config(
       scan_pub_ != nullptr, config_.scan_output.flatten);
+    auto merge_t0 = std::chrono::steady_clock::now();
     auto result = merge_engine_->merge_pipeline(inputs, pcfg);
+    log_merge_perf(std::chrono::duration<double, std::micro>(
+      std::chrono::steady_clock::now() - merge_t0).count(), "CUDA");
     if (!result.cloud || result.cloud->empty()) return;
 
     if (cloud_pub_) {
@@ -305,7 +326,10 @@ void PolkaNode::output_callback()
       last_scan_ranges_ = result.scan_ranges;
     }
   } else {
+    auto merge_t0 = std::chrono::steady_clock::now();
     auto merged = merge_engine_->merge(inputs);
+    log_merge_perf(std::chrono::duration<double, std::micro>(
+      std::chrono::steady_clock::now() - merge_t0).count(), "CPU");
     if (!merged || merged->empty()) return;
 
     if (config_.point_timestamps.enabled && config_.cloud_output.voxel.enabled)

--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -20,7 +20,6 @@
 #include <sensor_msgs/msg/point_field.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
-#include <chrono>
 #include <cstring>
 
 namespace polka {
@@ -279,10 +278,10 @@ void SourceAdapter::pc2_callback(sensor_msgs::msg::PointCloud2::ConstSharedPtr m
       deskew_max_us_ = std::max(deskew_max_us_, us);
       if (++deskew_calls_ % kPerfLogInterval == 0) {
         RCLCPP_INFO(logger_,
-          "polka: perf source '%s' deskew: mean=%.3fms max=%.3fms (n=%zu pts, over %llu calls)",
+          "polka: perf source '%s' deskew: mean=%.3fms max=%.3fms (n=%zu pts, over %zu calls)",
           config_.name.c_str(), deskew_total_us_ / kPerfLogInterval / 1000.0,
           deskew_max_us_ / 1000.0, cloud->size(),
-          static_cast<unsigned long long>(kPerfLogInterval));
+          static_cast<size_t>(kPerfLogInterval));
         deskew_total_us_ = 0.0;
         deskew_max_us_ = 0.0;
       }

--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -13,26 +13,30 @@
 // limitations under the License.
 
 #include "polka/input/source_adapter.hpp"
-#include "polka/util/se3_exp.hpp"
-#include "polka/filters/filter_chain.hpp"
 
 #include <pcl_conversions/pcl_conversions.h>
-#include <sensor_msgs/msg/point_field.hpp>
-#include <tf2_eigen/tf2_eigen.hpp>
 
 #include <cstring>
 
-namespace polka {
+#include "polka/util/se3_exp.hpp"
+#include "polka/filters/filter_chain.hpp"
+#include <sensor_msgs/msg/point_field.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
 
-namespace {
+namespace polka
+{
+
+namespace
+{
 constexpr uint64_t kPerfLogInterval = 50;
 }
 
-SourceAdapter::SourceAdapter(rclcpp::Node * node, const SourceConfig & config, bool gpu_filters,
-                             ImuGetter imu_getter, bool deskew_enabled,
-                             const std::string & timestamp_field_hint,
-                             std::shared_ptr<tf2_ros::Buffer> tf_buffer,
-                             int imu_buffer_size)
+SourceAdapter::SourceAdapter(
+  rclcpp::Node * node, const SourceConfig & config, bool gpu_filters,
+  ImuGetter imu_getter, bool deskew_enabled,
+  const std::string & timestamp_field_hint,
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+  int imu_buffer_size)
 : node_(node), config_(config), logger_(node->get_logger()), gpu_filters_(gpu_filters),
   get_imu_(std::move(imu_getter)), deskew_enabled_(deskew_enabled),
   timestamp_field_hint_(timestamp_field_hint), tf_buffer_(std::move(tf_buffer))
@@ -41,9 +45,10 @@ SourceAdapter::SourceAdapter(rclcpp::Node * node, const SourceConfig & config, b
   if (deskew_enabled_ && !config.imu_topic.empty()) {
     local_imu_ = std::make_shared<ImuBuffer>(node, config.imu_topic, imu_buffer_size);
     get_imu_ = [this]() -> std::shared_ptr<const AveragedImu> {
-      return local_imu_->snapshot();
-    };
-    RCLCPP_INFO(logger_, "polka: source '%s' using per-source IMU on '%s'",
+        return local_imu_->snapshot();
+      };
+    RCLCPP_INFO(
+      logger_, "polka: source '%s' using per-source IMU on '%s'",
       config.name.c_str(), config.imu_topic.c_str());
   }
   // Build QoS
@@ -65,10 +70,12 @@ SourceAdapter::SourceAdapter(rclcpp::Node * node, const SourceConfig & config, b
       std::bind(&SourceAdapter::scan_callback, this, std::placeholders::_1));
   }
 
-  if (!gpu_filters_)
+  if (!gpu_filters_) {
     filters_ = build_filter_chain(config.filter_params);
+  }
 
-  RCLCPP_INFO(logger_, "polka: source '%s' subscribed to '%s' (%s), %zu filters%s",
+  RCLCPP_INFO(
+    logger_, "polka: source '%s' subscribed to '%s' (%s), %zu filters%s",
     config.name.c_str(), config.topic.c_str(),
     config.type == SourceType::POINTCLOUD2 ? "PointCloud2" : "LaserScan",
     filters_.size(),
@@ -79,20 +86,28 @@ bool SourceAdapter::validate_fields(const sensor_msgs::msg::PointCloud2 & msg)
 {
   bool has_x = false, has_y = false, has_z = false, has_intensity = false;
   for (const auto & field : msg.fields) {
-    if (field.name == "x" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) has_x = true;
-    if (field.name == "y" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) has_y = true;
-    if (field.name == "z" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) has_z = true;
-    if (field.name == "intensity") has_intensity = true;
+    if (field.name == "x" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) {
+      has_x = true;
+    }
+    if (field.name == "y" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) {
+      has_y = true;
+    }
+    if (field.name == "z" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) {
+      has_z = true;
+    }
+    if (field.name == "intensity") {has_intensity = true;}
   }
   if (!has_x || !has_y || !has_z) {
-    RCLCPP_ERROR(logger_,
+    RCLCPP_ERROR(
+      logger_,
       "polka: source '%s' missing required FLOAT32 x/y/z fields - dropping all messages",
       config_.name.c_str());
     return false;
   }
   missing_intensity_ = !has_intensity;
   if (missing_intensity_) {
-    RCLCPP_WARN(logger_,
+    RCLCPP_WARN(
+      logger_,
       "polka: source '%s' missing 'intensity' field - publishing with intensity=0",
       config_.name.c_str());
   }
@@ -120,11 +135,13 @@ void SourceAdapter::detect_timestamp_field(const sensor_msgs::msg::PointCloud2 &
     for (const auto & name : candidates) {
       if (field.name == name) {
         if (field.datatype == sensor_msgs::msg::PointField::FLOAT32 ||
-            field.datatype == sensor_msgs::msg::PointField::FLOAT64) {
+          field.datatype == sensor_msgs::msg::PointField::FLOAT64)
+        {
           has_timestamp_field_ = true;
           timestamp_field_offset_ = field.offset;
           timestamp_field_datatype_ = field.datatype;
-          RCLCPP_INFO(logger_,
+          RCLCPP_INFO(
+            logger_,
             "polka: source '%s' detected per-point timestamp field '%s' (offset=%u, %s)",
             config_.name.c_str(), field.name.c_str(), field.offset,
             field.datatype == sensor_msgs::msg::PointField::FLOAT64 ? "FLOAT64" : "FLOAT32");
@@ -134,7 +151,8 @@ void SourceAdapter::detect_timestamp_field(const sensor_msgs::msg::PointCloud2 &
     }
   }
 
-  RCLCPP_INFO(logger_,
+  RCLCPP_INFO(
+    logger_,
     "polka: source '%s' has no per-point timestamp field, per-point deskewing disabled",
     config_.name.c_str());
 }
@@ -162,9 +180,11 @@ void SourceAdapter::populate_point_time(
   // No per-point field (or layout we cannot index safely): every point inherits
   // the message header stamp. Same fallback used for projected LaserScan sources.
   if (!has_timestamp_field_ ||
-      n != static_cast<size_t>(raw_msg.width) * raw_msg.height) {
-    for (size_t i = 0; i < n; ++i)
+    n != static_cast<size_t>(raw_msg.width) * raw_msg.height)
+  {
+    for (size_t i = 0; i < n; ++i) {
       cloud[i].time = header_sec;
+    }
     return;
   }
 
@@ -185,13 +205,13 @@ void SourceAdapter::deskew_cloud(
   const AveragedImu & imu)
 {
   size_t n = cloud.size();
-  if (n == 0 || n != static_cast<size_t>(raw_msg.width) * raw_msg.height) return;
+  if (n == 0 || n != static_cast<size_t>(raw_msg.width) * raw_msg.height) {return;}
 
   // Rotate IMU data from IMU frame into sensor frame (identity if same frame or TF unavailable)
   Eigen::Matrix3d R_imu_to_sensor = Eigen::Matrix3d::Identity();
   if (tf_buffer_ && !imu.frame_id.empty()) {
     std::string sensor_frame;
-    { std::lock_guard<std::mutex> lock(meta_mutex_); sensor_frame = frame_id_; }
+    {std::lock_guard<std::mutex> lock(meta_mutex_); sensor_frame = frame_id_;}
     if (!sensor_frame.empty() && sensor_frame != imu.frame_id) {
       try {
         auto tf_msg = tf_buffer_->lookupTransform(
@@ -216,7 +236,7 @@ void SourceAdapter::deskew_cloud(
     // Interpret: if >1e8 it's absolute Unix time, otherwise relative offset from scan start
     double dt = (pt_time > 1e8) ? (pt_time - header_sec) : pt_time;
 
-    if (std::abs(dt) < 1e-9) continue;
+    if (std::abs(dt) < 1e-9) {continue;}
 
     Eigen::Isometry3d delta = compute_motion_delta(angular_vel, accel, dt);
     Eigen::Vector3d p(cloud[i].x, cloud[i].y, cloud[i].z);
@@ -253,11 +273,12 @@ void SourceAdapter::pc2_callback(sensor_msgs::msg::PointCloud2::ConstSharedPtr m
     fields_validated_ = true;
     fields_valid_ = validate_fields(*msg);
   }
-  if (!fields_valid_) return;
+  if (!fields_valid_) {return;}
 
   // Detect per-point timestamp field on first message
-  if (!timestamp_field_detected_)
+  if (!timestamp_field_detected_) {
     detect_timestamp_field(*msg);
+  }
 
   auto cloud = std::make_shared<CloudT>();
   pcl::fromROSMsg(*msg, *cloud);
@@ -277,7 +298,8 @@ void SourceAdapter::pc2_callback(sensor_msgs::msg::PointCloud2::ConstSharedPtr m
       deskew_total_us_ += us;
       deskew_max_us_ = std::max(deskew_max_us_, us);
       if (++deskew_calls_ % kPerfLogInterval == 0) {
-        RCLCPP_INFO(logger_,
+        RCLCPP_INFO(
+          logger_,
           "polka: perf source '%s' deskew: mean=%.3fms max=%.3fms (n=%zu pts, over %zu calls)",
           config_.name.c_str(), deskew_total_us_ / kPerfLogInterval / 1000.0,
           deskew_max_us_ / 1000.0, cloud->size(),
@@ -302,7 +324,7 @@ void SourceAdapter::scan_callback(sensor_msgs::msg::LaserScan::ConstSharedPtr ms
     fields_validated_ = true;
     fields_valid_ = validate_fields(pc2_msg);
   }
-  if (!fields_valid_) return;
+  if (!fields_valid_) {return;}
 
   auto cloud = std::make_shared<CloudT>();
   pcl::fromROSMsg(pc2_msg, *cloud);
@@ -325,7 +347,7 @@ std::string SourceAdapter::frame_id() const
 
 bool SourceAdapter::is_stale(double timeout_sec, const rclcpp::Time & now) const
 {
-  if (!has_received_.load()) return true;
+  if (!has_received_.load()) {return true;}
   std::lock_guard<std::mutex> lock(meta_mutex_);
   return (now - last_received_time_).seconds() > timeout_sec;
 }
@@ -340,8 +362,9 @@ void SourceAdapter::rebuild_filters(const FilterParams & fp)
 {
   config_.filter_params = fp;
   filters_.clear();
-  if (!gpu_filters_)
+  if (!gpu_filters_) {
     filters_ = build_filter_chain(fp);
+  }
 }
 
 }  // namespace polka

--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -20,9 +20,14 @@
 #include <sensor_msgs/msg/point_field.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
+#include <chrono>
 #include <cstring>
 
 namespace polka {
+
+namespace {
+constexpr uint64_t kPerfLogInterval = 50;
+}
 
 SourceAdapter::SourceAdapter(rclcpp::Node * node, const SourceConfig & config, bool gpu_filters,
                              ImuGetter imu_getter, bool deskew_enabled,
@@ -265,8 +270,23 @@ void SourceAdapter::pc2_callback(sensor_msgs::msg::PointCloud2::ConstSharedPtr m
   // Per-point deskewing (before filters, in sensor frame)
   if (deskew_enabled_ && has_timestamp_field_ && get_imu_) {
     auto imu = get_imu_();
-    if (imu && imu->valid)
+    if (imu && imu->valid) {
+      auto t0 = std::chrono::steady_clock::now();
       deskew_cloud(*cloud, *msg, *imu);
+      double us = std::chrono::duration<double, std::micro>(
+        std::chrono::steady_clock::now() - t0).count();
+      deskew_total_us_ += us;
+      deskew_max_us_ = std::max(deskew_max_us_, us);
+      if (++deskew_calls_ % kPerfLogInterval == 0) {
+        RCLCPP_INFO(logger_,
+          "polka: perf source '%s' deskew: mean=%.3fms max=%.3fms (n=%zu pts, over %llu calls)",
+          config_.name.c_str(), deskew_total_us_ / kPerfLogInterval / 1000.0,
+          deskew_max_us_ / 1000.0, cloud->size(),
+          static_cast<unsigned long long>(kPerfLogInterval));
+        deskew_total_us_ = 0.0;
+        deskew_max_us_ = 0.0;
+      }
+    }
   }
 
   apply_filters(*cloud);


### PR DESCRIPTION
Skips SE(3) left Jacobian when rotation only (rho exactly zero): exact no op, not an approximation.

* Deskew latency down about 20 percent per source in a clean back to back A/B rebuild
* Correctness recheck: optimized output differs from baseline less than baseline's own rerun noise floor
* Real bag gate: displacement scales with range and IMU motion, ruling out on equals off
* Fixed repo wide cpplint and uncrustify failures predating this change, all 7 lint checks pass locally
* Follow up specced not implemented: precompute exp map at coarse stride and interpolate for fewer transcendental calls

Full numbers and the one open item are in DESKEW_PERF_REPORT.md.