### PR TITLE
fix: doc/media flake8 and pep257 lint violations

### DIFF
--- a/doc/media/capture_all.py
+++ b/doc/media/capture_all.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Capture every feature config sequentially via run_capture.py subprocesses.
+"""
+Capture every feature config sequentially via run_capture.py subprocesses.
 
 Each run is an isolated subprocess (avoids rclpy re-init and process-group
 signal issues from looping captures in one shell). Run from the ws root with

--- a/doc/media/demo_bringup.launch.py
+++ b/doc/media/demo_bringup.launch.py
@@ -1,4 +1,5 @@
-"""Capture bringup: polka_node + static transforms from the TIERS dataset extrinsics.
+"""
+Capture bringup: polka_node + static transforms from the TIERS dataset extrinsics.
 
 The Calibration.bag carries no TF. OS1 (`os_sensor`) is the base reference; the
 other sensors are placed relative to it using the dataset README extrinsics.

--- a/doc/media/gen_configs.py
+++ b/doc/media/gen_configs.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Generate per-feature polka configs for the demo GIFs.
+"""
+Generate per-feature polka configs for the demo GIFs.
 
 All configs share a base (3-LiDAR sources, os_sensor output frame); each feature
 variant flips one knob. Run: `python3 gen_configs.py` -> writes media/configs/*.yaml
 """
-import copy
 import pathlib
 
 import yaml
@@ -23,9 +23,15 @@ SRC_DEF = {
 def source_block(names):
     # reliable + deeper queue: the 2.3 MB Ouster cloud is dropped under
     # best_effort/depth-1 when the single-threaded executor is busy.
-    return {n: {"topic": SRC_DEF[n]["topic"], "type": "pointcloud2",
-               "qos_reliability": "reliable", "qos_history_depth": 10}
-            for n in names}
+    return {
+        n: {
+            "topic": SRC_DEF[n]["topic"],
+            "type": "pointcloud2",
+            "qos_reliability": "reliable",
+            "qos_history_depth": 10,
+        }
+        for n in names
+    }
 
 
 def base():
@@ -86,39 +92,49 @@ def main():
     configs["single"] = single
 
     # output filters, each alone
-    c = base(); cloud(c)["filters"]["range"]["enabled"] = True
+    c = base()
+    cloud(c)["filters"]["range"]["enabled"] = True
     configs["filter_range"] = c
-    c = base(); cloud(c)["filters"]["angular"]["enabled"] = True
+    c = base()
+    cloud(c)["filters"]["angular"]["enabled"] = True
     configs["filter_angular"] = c
-    c = base(); cloud(c)["filters"]["box"]["enabled"] = True
+    c = base()
+    cloud(c)["filters"]["box"]["enabled"] = True
     configs["filter_box"] = c
-    c = base(); cloud(c)["height_cap"]["enabled"] = True
+    c = base()
+    cloud(c)["height_cap"]["enabled"] = True
     configs["filter_height"] = c
 
     # angular invert flag
-    c = base(); cloud(c)["filters"]["angular"]["enabled"] = True
+    c = base()
+    cloud(c)["filters"]["angular"]["enabled"] = True
     cloud(c)["filters"]["angular"]["invert"] = False
     configs["invert_keep"] = c
-    c = base(); cloud(c)["filters"]["angular"]["enabled"] = True
+    c = base()
+    cloud(c)["filters"]["angular"]["enabled"] = True
     cloud(c)["filters"]["angular"]["invert"] = True
     configs["invert_exclude"] = c
 
     # self filter
-    c = base(); cloud(c)["self_filter"]["enabled"] = True
+    c = base()
+    cloud(c)["self_filter"]["enabled"] = True
     configs["self_on"] = c
 
     # voxel
-    c = base(); cloud(c)["voxel"]["enabled"] = True
+    c = base()
+    cloud(c)["voxel"]["enabled"] = True
     cloud(c)["voxel"]["leaf_size"] = 0.2
     configs["voxel_on"] = c
 
     # cpu vs cuda
-    c = base(); c["polka"]["ros__parameters"]["enable_gpu"] = False
+    c = base()
+    c["polka"]["ros__parameters"]["enable_gpu"] = False
     configs["cpu"] = c
     # (cuda == merged: enable_gpu True)
 
     # dual output (cloud + scan)
-    c = base(); c["polka"]["ros__parameters"]["outputs"]["scan"]["enabled"] = True
+    c = base()
+    c["polka"]["ros__parameters"]["outputs"]["scan"]["enabled"] = True
     configs["dual"] = c
 
     # per-source 2D scans (single source, scan output) for the scan-merge demo

--- a/doc/media/prepare_bag.py
+++ b/doc/media/prepare_bag.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Prepare the TIERS Calibration.bag (ROS 1) as a clean ROS 2 mcap for polka.
+"""
+Prepare the TIERS Calibration.bag (ROS 1) as a clean ROS 2 mcap for polka.
 
 One pass over the ROS 1 bag:
   /ouster/points             (PointCloud2)                   -> passthrough
@@ -95,7 +96,9 @@ def ros1_pc2_to_ros2(m):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--in", dest="inp", default=str(pathlib.Path.home() / "Downloads/Calibration.bag"))
+    ap.add_argument(
+        "--in", dest="inp",
+        default=str(pathlib.Path.home() / "Downloads/Calibration.bag"))
     ap.add_argument("--out", default=str(pathlib.Path.home() / "ros2_ws/bags/calibration_ros2"))
     ap.add_argument("--limit", type=int, default=0, help="stop after N messages (debug)")
     ap.add_argument("--accumulate", type=int, default=40,

--- a/doc/media/render_o3d.py
+++ b/doc/media/render_o3d.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Render per-feature demo panels with Open3D offscreen + matplotlib compositing.
+"""
+Render per-feature demo panels with Open3D offscreen + matplotlib compositing.
 
 Open3D's GPU offscreen renderer draws the point-cloud pixels (depth, AA); a thin
 matplotlib layer composes the divided panel with titles/labels. One panel = a
@@ -169,8 +170,12 @@ class Renderer:
 def scan_img(xy, lim=12.0):
     """Top-down 2D scan render via matplotlib, returned as an RGB array."""
     fig = plt.figure(figsize=(TILE / 100, TILE / 100), dpi=100, facecolor=BG[:3])
-    ax = fig.add_axes([0, 0, 1, 1]); ax.set_facecolor(BG[:3])
-    ax.set_xlim(-lim, lim); ax.set_ylim(-lim, lim); ax.set_aspect("equal"); ax.axis("off")
+    ax = fig.add_axes([0, 0, 1, 1])
+    ax.set_facecolor(BG[:3])
+    ax.set_xlim(-lim, lim)
+    ax.set_ylim(-lim, lim)
+    ax.set_aspect("equal")
+    ax.axis("off")
     if xy.shape[0] > 0:
         rr = np.hypot(xy[:, 0], xy[:, 1])
         ax.scatter(xy[:, 0], xy[:, 1], c=rr, cmap="turbo", s=6, linewidths=0)
@@ -188,7 +193,8 @@ def compose(imgL, imgR, title, labelL, labelR, footL, footR, out_png):
                  weight="bold", y=0.965)
     for i, (img, lab, foot) in enumerate([(imgL, labelL, footL), (imgR, labelR, footR)]):
         ax = fig.add_subplot(1, 2, i + 1)
-        ax.imshow(img); ax.axis("off")
+        ax.imshow(img)
+        ax.axis("off")
         ax.text(0.03, 0.95, lab, transform=ax.transAxes, color="white",
                 fontsize=20, family="monospace", weight="bold", va="top")
         ax.text(0.03, 0.04, foot, transform=ax.transAxes, color="#bbb",
@@ -258,7 +264,9 @@ def main():
     args = ap.parse_args()
 
     eye, center, up = compute_camera(args.work)
-    print(f"camera eye={[round(v,2) for v in eye]} center={[round(v,2) for v in center]}", flush=True)
+    eye_r = [round(v, 2) for v in eye]
+    center_r = [round(v, 2) for v in center]
+    print(f"camera eye={eye_r} center={center_r}", flush=True)
     renderer = Renderer(eye, center, up)
 
     names = [args.only] if args.only else list(PANELS.keys())

--- a/doc/media/render_scan.py
+++ b/doc/media/render_scan.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Render the 2D LaserScan merge panel.
+"""
+Render the 2D LaserScan merge panel.
 
 Left:  each lidar's own flattened scan, overlaid and color-coded.
 Right: the merged scan, where every beam is colored by the sensor that *won*
@@ -36,8 +37,12 @@ COLORS = [c for _, _, c in SOURCES]
 
 
 def read_scan_ranges(run_dir):
-    """Return (list of per-frame range arrays with NaN for invalid bins,
-    angle_min, angle_increment)."""
+    """
+    Return per-frame range arrays plus scan geometry.
+
+    Returns (frames, angle_min, angle_increment), where frames is a list of
+    per-frame range arrays with NaN for invalid bins.
+    """
     d = run_dir / "run"
     if not d.is_dir():
         d = run_dir
@@ -60,8 +65,11 @@ def read_scan_ranges(run_dir):
 
 def style(ax, title):
     ax.set_facecolor(BG)
-    ax.set_xlim(-LIM, LIM); ax.set_ylim(-LIM, LIM); ax.set_aspect("equal")
-    ax.set_xticks([]); ax.set_yticks([])
+    ax.set_xlim(-LIM, LIM)
+    ax.set_ylim(-LIM, LIM)
+    ax.set_aspect("equal")
+    ax.set_xticks([])
+    ax.set_yticks([])
     for s in ax.spines.values():
         s.set_color("#333")
     ax.plot(0, 0, marker="^", color="white", markersize=15, zorder=5)

--- a/doc/media/run_capture.py
+++ b/doc/media/run_capture.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Capture one polka run: output bag + performance metrics sidecar.
+"""
+Capture one polka run: output bag + performance metrics sidecar.
 
 Launches demo_bringup.launch.py (polka_node + static TFs) with a config, plays
 the converted calibration bag, samples CPU/RAM/GPU + end-to-end latency, and
@@ -178,9 +179,11 @@ def run_once(config_yaml, out_dir, bag_path, duration, warmup=3.0):
     stop_evt = threading.Event()
     cpu_pct, rss_mb, gpu_pct = [], [], []
     proc = psutil.Process(polka_node_pid)
-    th_cpu = threading.Thread(target=sample_psutil, args=(proc, stop_evt, cpu_pct, rss_mb), daemon=True)
+    th_cpu = threading.Thread(
+        target=sample_psutil, args=(proc, stop_evt, cpu_pct, rss_mb), daemon=True)
     th_gpu = threading.Thread(target=sample_gpu, args=(stop_evt, gpu_pct), daemon=True)
-    th_cpu.start(); th_gpu.start()
+    th_cpu.start()
+    th_gpu.start()
 
     end_time = time.monotonic() + duration
     while time.monotonic() < end_time:
@@ -189,7 +192,8 @@ def run_once(config_yaml, out_dir, bag_path, duration, warmup=3.0):
     stop_evt.set()
     kill_tree(play_proc.pid)
     kill_tree(polka_proc.pid)
-    th_cpu.join(timeout=2); th_gpu.join(timeout=2)
+    th_cpu.join(timeout=2)
+    th_gpu.join(timeout=2)
 
     latencies = node.latencies_ms[:]
     node.close()
@@ -207,7 +211,9 @@ def run_once(config_yaml, out_dir, bag_path, duration, warmup=3.0):
     with open(out_dir / "metrics.json", "w") as f:
         json.dump(metrics, f, indent=2)
 
-    print(f"  metrics: n_lat={len(latencies)} n_cpu={len(cpu_pct)} n_gpu={len(gpu_pct)}", flush=True)
+    print(
+        f"  metrics: n_lat={len(latencies)} n_cpu={len(cpu_pct)} n_gpu={len(gpu_pct)}",
+        flush=True)
     if not latencies:
         print("  WARN: no merged_cloud messages received", flush=True)
         return None


### PR DESCRIPTION
Fixes pre existing lint failures in doc/media scripts, unrelated to any feature work.

* Removed unused import in gen_configs.py
* Split semicolon joined statements flagged by flake8 E702
* Wrapped long argument lines flagged by E501
* Moved module and function docstring summaries to the second line per the ament pep257 D213 convention
* Verified locally against the exact ament_flake8 and ament_pep257 configs, zero violations

These files were added in a prior commit without lint ever passing, so every PR into humble inherits this failure through the merge ref check regardless of what it changes.