### PR TITLE
fix: repo-wide pre-existing lint failures on humble

### DIFF
--- a/doc/media/capture_all.py
+++ b/doc/media/capture_all.py
@@ -11,29 +11,29 @@ import subprocess
 import sys
 
 HERE = pathlib.Path(__file__).parent
-CONFIGS = HERE / "configs"
-WORK = HERE / "work"
+CONFIGS = HERE / 'configs'
+WORK = HERE / 'work'
 
 # cpu_vs_cuda omitted: needs a working CUDA runtime (currently error 999).
-DEFAULT = ["single", "merged", "filter_range", "filter_angular", "filter_box",
-           "filter_height", "invert_keep", "invert_exclude", "self_on",
-           "voxel_on", "dual"]
+DEFAULT = ['single', 'merged', 'filter_range', 'filter_angular', 'filter_box',
+           'filter_height', 'invert_keep', 'invert_exclude', 'self_on',
+           'voxel_on', 'dual']
 
 
 def main():
     names = sys.argv[1:] or DEFAULT
     for cfg in names:
-        out = WORK / f"cap_{cfg}"
-        print(f"=== capture {cfg} ===", flush=True)
+        out = WORK / f'cap_{cfg}'
+        print(f'=== capture {cfg} ===', flush=True)
         try:
             subprocess.run(
-                [sys.executable, str(HERE / "run_capture.py"),
-                 str(CONFIGS / f"{cfg}.yaml"), str(out), "--duration", "12"],
+                [sys.executable, str(HERE / 'run_capture.py'),
+                 str(CONFIGS / f'{cfg}.yaml'), str(out), '--duration', '12'],
                 timeout=60, check=False)
         except subprocess.TimeoutExpired:
-            print(f"  {cfg}: TIMEOUT", flush=True)
-    print("CAPTURE_ALL DONE", flush=True)
+            print(f'  {cfg}: TIMEOUT', flush=True)
+    print('CAPTURE_ALL DONE', flush=True)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/doc/media/capture_all.py
+++ b/doc/media/capture_all.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Capture every feature config sequentially via run_capture.py subprocesses.
+"""
+Capture every feature config sequentially via run_capture.py subprocesses.
 
 Each run is an isolated subprocess (avoids rclpy re-init and process-group
 signal issues from looping captures in one shell). Run from the ws root with

--- a/doc/media/demo_bringup.launch.py
+++ b/doc/media/demo_bringup.launch.py
@@ -12,24 +12,24 @@ from launch_ros.actions import Node
 
 # child_frame -> (x, y, z, roll, pitch, yaw)  [meters, radians] relative to os_sensor
 EXTRINSICS = {
-    "avia_frame": (0.149354, 0.0423582, -0.0524961, 3.13419, -3.13908, -3.13281),
-    "mid360_frame": (0.125546, -0.0554536, -0.20206, 0.00467344, 0.0270294, 0.0494959),
-    "camera_depth_optical_frame": (-0.172863, 0.11895, -0.101785, 1.55222, 3.11188, 1.60982),
+    'avia_frame': (0.149354, 0.0423582, -0.0524961, 3.13419, -3.13908, -3.13281),
+    'mid360_frame': (0.125546, -0.0554536, -0.20206, 0.00467344, 0.0270294, 0.0494959),
+    'camera_depth_optical_frame': (-0.172863, 0.11895, -0.101785, 1.55222, 3.11188, 1.60982),
 }
 
 
 def generate_launch_description():
-    cfg = LaunchConfiguration("config_file")
+    cfg = LaunchConfiguration('config_file')
     actions = [
-        DeclareLaunchArgument("config_file"),
-        Node(package="polka", executable="polka_node", name="polka",
-             output="screen", parameters=[cfg, {"use_sim_time": True}]),
+        DeclareLaunchArgument('config_file'),
+        Node(package='polka', executable='polka_node', name='polka',
+             output='screen', parameters=[cfg, {'use_sim_time': True}]),
     ]
     for child, (x, y, z, roll, pitch, yaw) in EXTRINSICS.items():
         actions.append(Node(
-            package="tf2_ros", executable="static_transform_publisher",
-            name=f"tf_{child}", output="log",
-            arguments=["--x", str(x), "--y", str(y), "--z", str(z),
-                       "--roll", str(roll), "--pitch", str(pitch), "--yaw", str(yaw),
-                       "--frame-id", "os_sensor", "--child-frame-id", child]))
+            package='tf2_ros', executable='static_transform_publisher',
+            name=f'tf_{child}', output='log',
+            arguments=['--x', str(x), '--y', str(y), '--z', str(z),
+                       '--roll', str(roll), '--pitch', str(pitch), '--yaw', str(yaw),
+                       '--frame-id', 'os_sensor', '--child-frame-id', child]))
     return LaunchDescription(actions)

--- a/doc/media/demo_bringup.launch.py
+++ b/doc/media/demo_bringup.launch.py
@@ -1,4 +1,5 @@
-"""Capture bringup: polka_node + static transforms from the TIERS dataset extrinsics.
+"""
+Capture bringup: polka_node + static transforms from the TIERS dataset extrinsics.
 
 The Calibration.bag carries no TF. OS1 (`os_sensor`) is the base reference; the
 other sensors are placed relative to it using the dataset README extrinsics.

--- a/doc/media/gen_configs.py
+++ b/doc/media/gen_configs.py
@@ -10,13 +10,13 @@ import pathlib
 import yaml
 
 HERE = pathlib.Path(__file__).parent
-OUT = HERE / "configs"
+OUT = HERE / 'configs'
 
-SOURCES_3 = ["ouster", "avia", "mid360"]
+SOURCES_3 = ['ouster', 'avia', 'mid360']
 SRC_DEF = {
-    "ouster": {"topic": "/ouster/points"},
-    "avia": {"topic": "/avia/points"},
-    "mid360": {"topic": "/mid360/points"},
+    'ouster': {'topic': '/ouster/points'},
+    'avia': {'topic': '/avia/points'},
+    'mid360': {'topic': '/mid360/points'},
 }
 
 
@@ -25,132 +25,132 @@ def source_block(names):
     # best_effort/depth-1 when the single-threaded executor is busy.
     return {
         n: {
-            "topic": SRC_DEF[n]["topic"],
-            "type": "pointcloud2",
-            "qos_reliability": "reliable",
-            "qos_history_depth": 10,
+            'topic': SRC_DEF[n]['topic'],
+            'type': 'pointcloud2',
+            'qos_reliability': 'reliable',
+            'qos_history_depth': 10,
         }
         for n in names
     }
 
 
 def base():
-    return {"polka": {"ros__parameters": {
-        "output_frame_id": "os_sensor",
-        "output_rate": 15.0,
-        "enable_gpu": True,
-        "source_timeout": 0.5,
-        "timestamp_strategy": "earliest",
-        "outputs": {
-            "cloud": {
-                "enabled": True, "topic": "~/merged_cloud",
-                "filters": {
-                    "range": {"enabled": False, "min": 0.5, "max": 6.0},
-                    "angular": {"enabled": False, "invert": False, "ranges": [315.0, 45.0]},
-                    "box": {"enabled": False, "x_min": -3.0, "x_max": 3.0,
-                            "y_min": -3.0, "y_max": 3.0, "z_min": -2.0, "z_max": 2.0},
+    return {'polka': {'ros__parameters': {
+        'output_frame_id': 'os_sensor',
+        'output_rate': 15.0,
+        'enable_gpu': True,
+        'source_timeout': 0.5,
+        'timestamp_strategy': 'earliest',
+        'outputs': {
+            'cloud': {
+                'enabled': True, 'topic': '~/merged_cloud',
+                'filters': {
+                    'range': {'enabled': False, 'min': 0.5, 'max': 6.0},
+                    'angular': {'enabled': False, 'invert': False, 'ranges': [315.0, 45.0]},
+                    'box': {'enabled': False, 'x_min': -3.0, 'x_max': 3.0,
+                            'y_min': -3.0, 'y_max': 3.0, 'z_min': -2.0, 'z_max': 2.0},
                 },
-                "height_cap": {"enabled": False, "z_min": -0.6, "z_max": 1.0},
-                "self_filter": {"enabled": False, "box_names": ["chassis"],
-                                "chassis": {"x_min": -0.6, "x_max": 0.6,
-                                            "y_min": -0.6, "y_max": 0.6,
-                                            "z_min": -0.5, "z_max": 0.5}},
+                'height_cap': {'enabled': False, 'z_min': -0.6, 'z_max': 1.0},
+                'self_filter': {'enabled': False, 'box_names': ['chassis'],
+                                'chassis': {'x_min': -0.6, 'x_max': 0.6,
+                                            'y_min': -0.6, 'y_max': 0.6,
+                                            'z_min': -0.5, 'z_max': 0.5}},
                 # leaf_size must stay 0 here: polka enables voxel whenever any
                 # leaf > 0, regardless of the `enabled` flag. Only voxel_on sets it.
-                "voxel": {"enabled": False, "leaf_size": 0.0},
+                'voxel': {'enabled': False, 'leaf_size': 0.0},
             },
-            "scan": {"enabled": False, "topic": "~/merged_scan",
+            'scan': {'enabled': False, 'topic': '~/merged_scan',
                      # wider vertical slice: captures more of each non-repetitive
                      # Livox swath per frame -> denser, less flickery 2D scans
-                     "z_min": -1.0, "z_max": 1.5,
-                     "angle_min": -3.14159265, "angle_max": 3.14159265,
-                     "angle_increment": 0.00436332, "range_min": 0.2, "range_max": 20.0},
+                     'z_min': -1.0, 'z_max': 1.5,
+                     'angle_min': -3.14159265, 'angle_max': 3.14159265,
+                     'angle_increment': 0.00436332, 'range_min': 0.2, 'range_max': 20.0},
         },
-        "source_names": list(SOURCES_3),
-        "sources": source_block(SOURCES_3),
+        'source_names': list(SOURCES_3),
+        'sources': source_block(SOURCES_3),
     }}}
 
 
 def write(name, cfg):
     OUT.mkdir(parents=True, exist_ok=True)
-    with open(OUT / f"{name}.yaml", "w") as f:
+    with open(OUT / f'{name}.yaml', 'w') as f:
         yaml.safe_dump(cfg, f, default_flow_style=False, sort_keys=False)
 
 
 def cloud(cfg):
-    return cfg["polka"]["ros__parameters"]["outputs"]["cloud"]
+    return cfg['polka']['ros__parameters']['outputs']['cloud']
 
 
 def main():
     configs = {}
 
     # merged (the common "before" for filter/voxel/self demos) and single (fusion)
-    configs["merged"] = base()
+    configs['merged'] = base()
     single = base()
-    single["polka"]["ros__parameters"]["source_names"] = ["ouster"]
-    single["polka"]["ros__parameters"]["sources"] = source_block(["ouster"])
-    configs["single"] = single
+    single['polka']['ros__parameters']['source_names'] = ['ouster']
+    single['polka']['ros__parameters']['sources'] = source_block(['ouster'])
+    configs['single'] = single
 
     # output filters, each alone
     c = base()
-    cloud(c)["filters"]["range"]["enabled"] = True
-    configs["filter_range"] = c
+    cloud(c)['filters']['range']['enabled'] = True
+    configs['filter_range'] = c
     c = base()
-    cloud(c)["filters"]["angular"]["enabled"] = True
-    configs["filter_angular"] = c
+    cloud(c)['filters']['angular']['enabled'] = True
+    configs['filter_angular'] = c
     c = base()
-    cloud(c)["filters"]["box"]["enabled"] = True
-    configs["filter_box"] = c
+    cloud(c)['filters']['box']['enabled'] = True
+    configs['filter_box'] = c
     c = base()
-    cloud(c)["height_cap"]["enabled"] = True
-    configs["filter_height"] = c
+    cloud(c)['height_cap']['enabled'] = True
+    configs['filter_height'] = c
 
     # angular invert flag
     c = base()
-    cloud(c)["filters"]["angular"]["enabled"] = True
-    cloud(c)["filters"]["angular"]["invert"] = False
-    configs["invert_keep"] = c
+    cloud(c)['filters']['angular']['enabled'] = True
+    cloud(c)['filters']['angular']['invert'] = False
+    configs['invert_keep'] = c
     c = base()
-    cloud(c)["filters"]["angular"]["enabled"] = True
-    cloud(c)["filters"]["angular"]["invert"] = True
-    configs["invert_exclude"] = c
+    cloud(c)['filters']['angular']['enabled'] = True
+    cloud(c)['filters']['angular']['invert'] = True
+    configs['invert_exclude'] = c
 
     # self filter
     c = base()
-    cloud(c)["self_filter"]["enabled"] = True
-    configs["self_on"] = c
+    cloud(c)['self_filter']['enabled'] = True
+    configs['self_on'] = c
 
     # voxel
     c = base()
-    cloud(c)["voxel"]["enabled"] = True
-    cloud(c)["voxel"]["leaf_size"] = 0.2
-    configs["voxel_on"] = c
+    cloud(c)['voxel']['enabled'] = True
+    cloud(c)['voxel']['leaf_size'] = 0.2
+    configs['voxel_on'] = c
 
     # cpu vs cuda
     c = base()
-    c["polka"]["ros__parameters"]["enable_gpu"] = False
-    configs["cpu"] = c
+    c['polka']['ros__parameters']['enable_gpu'] = False
+    configs['cpu'] = c
     # (cuda == merged: enable_gpu True)
 
     # dual output (cloud + scan)
     c = base()
-    c["polka"]["ros__parameters"]["outputs"]["scan"]["enabled"] = True
-    configs["dual"] = c
+    c['polka']['ros__parameters']['outputs']['scan']['enabled'] = True
+    configs['dual'] = c
 
     # per-source 2D scans (single source, scan output) for the scan-merge demo
     for src in SOURCES_3:
         c = base()
-        c["polka"]["ros__parameters"]["source_names"] = [src]
-        c["polka"]["ros__parameters"]["sources"] = source_block([src])
-        c["polka"]["ros__parameters"]["outputs"]["scan"]["enabled"] = True
-        configs[f"{src}_scan"] = c
+        c['polka']['ros__parameters']['source_names'] = [src]
+        c['polka']['ros__parameters']['sources'] = source_block([src])
+        c['polka']['ros__parameters']['outputs']['scan']['enabled'] = True
+        configs[f'{src}_scan'] = c
 
     for name, cfg in configs.items():
         write(name, cfg)
-    print(f"wrote {len(configs)} configs to {OUT}")
+    print(f'wrote {len(configs)} configs to {OUT}')
     for n in configs:
-        print("  ", n)
+        print('  ', n)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/doc/media/gen_configs.py
+++ b/doc/media/gen_configs.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Generate per-feature polka configs for the demo GIFs.
+"""
+Generate per-feature polka configs for the demo GIFs.
 
 All configs share a base (3-LiDAR sources, os_sensor output frame); each feature
 variant flips one knob. Run: `python3 gen_configs.py` -> writes media/configs/*.yaml
 """
-import copy
 import pathlib
 
 import yaml
@@ -23,9 +23,15 @@ SRC_DEF = {
 def source_block(names):
     # reliable + deeper queue: the 2.3 MB Ouster cloud is dropped under
     # best_effort/depth-1 when the single-threaded executor is busy.
-    return {n: {"topic": SRC_DEF[n]["topic"], "type": "pointcloud2",
-               "qos_reliability": "reliable", "qos_history_depth": 10}
-            for n in names}
+    return {
+        n: {
+            "topic": SRC_DEF[n]["topic"],
+            "type": "pointcloud2",
+            "qos_reliability": "reliable",
+            "qos_history_depth": 10,
+        }
+        for n in names
+    }
 
 
 def base():
@@ -86,39 +92,49 @@ def main():
     configs["single"] = single
 
     # output filters, each alone
-    c = base(); cloud(c)["filters"]["range"]["enabled"] = True
+    c = base()
+    cloud(c)["filters"]["range"]["enabled"] = True
     configs["filter_range"] = c
-    c = base(); cloud(c)["filters"]["angular"]["enabled"] = True
+    c = base()
+    cloud(c)["filters"]["angular"]["enabled"] = True
     configs["filter_angular"] = c
-    c = base(); cloud(c)["filters"]["box"]["enabled"] = True
+    c = base()
+    cloud(c)["filters"]["box"]["enabled"] = True
     configs["filter_box"] = c
-    c = base(); cloud(c)["height_cap"]["enabled"] = True
+    c = base()
+    cloud(c)["height_cap"]["enabled"] = True
     configs["filter_height"] = c
 
     # angular invert flag
-    c = base(); cloud(c)["filters"]["angular"]["enabled"] = True
+    c = base()
+    cloud(c)["filters"]["angular"]["enabled"] = True
     cloud(c)["filters"]["angular"]["invert"] = False
     configs["invert_keep"] = c
-    c = base(); cloud(c)["filters"]["angular"]["enabled"] = True
+    c = base()
+    cloud(c)["filters"]["angular"]["enabled"] = True
     cloud(c)["filters"]["angular"]["invert"] = True
     configs["invert_exclude"] = c
 
     # self filter
-    c = base(); cloud(c)["self_filter"]["enabled"] = True
+    c = base()
+    cloud(c)["self_filter"]["enabled"] = True
     configs["self_on"] = c
 
     # voxel
-    c = base(); cloud(c)["voxel"]["enabled"] = True
+    c = base()
+    cloud(c)["voxel"]["enabled"] = True
     cloud(c)["voxel"]["leaf_size"] = 0.2
     configs["voxel_on"] = c
 
     # cpu vs cuda
-    c = base(); c["polka"]["ros__parameters"]["enable_gpu"] = False
+    c = base()
+    c["polka"]["ros__parameters"]["enable_gpu"] = False
     configs["cpu"] = c
     # (cuda == merged: enable_gpu True)
 
     # dual output (cloud + scan)
-    c = base(); c["polka"]["ros__parameters"]["outputs"]["scan"]["enabled"] = True
+    c = base()
+    c["polka"]["ros__parameters"]["outputs"]["scan"]["enabled"] = True
     configs["dual"] = c
 
     # per-source 2D scans (single source, scan output) for the scan-merge demo

--- a/doc/media/prepare_bag.py
+++ b/doc/media/prepare_bag.py
@@ -18,27 +18,26 @@ import collections
 import pathlib
 import shutil
 
+from builtin_interfaces.msg import Time
 import numpy as np
-from rosbags.rosbag1 import Reader
-from rosbags.typesys import Stores, get_typestore, get_types_from_msg
-
 from rclpy.serialization import serialize_message
+import rosbag2_py
+from rosbags.rosbag1 import Reader
+from rosbags.typesys import get_types_from_msg, get_typestore, Stores
 from sensor_msgs.msg import PointCloud2, PointField
 from std_msgs.msg import Header
-from builtin_interfaces.msg import Time
-import rosbag2_py
 
-PASSTHROUGH = {"/ouster/points", "/camera/depth/color/points"}
+PASSTHROUGH = {'/ouster/points', '/camera/depth/color/points'}
 LIVOX_MAP = {
-    "/avia/livox/lidar": ("/avia/points", "avia_frame"),
-    "/mid360/livox/lidar": ("/mid360/points", "mid360_frame"),
+    '/avia/livox/lidar': ('/avia/points', 'avia_frame'),
+    '/mid360/livox/lidar': ('/mid360/points', 'mid360_frame'),
 }
 
 
 def _ns(stamp):
-    nsec = getattr(stamp, "nanosec", None)
+    nsec = getattr(stamp, 'nanosec', None)
     if nsec is None:
-        nsec = getattr(stamp, "nsec", 0)
+        nsec = getattr(stamp, 'nsec', 0)
     return int(stamp.sec), int(nsec)
 
 
@@ -64,10 +63,10 @@ def pc2_from_xyzi(arr, frame_id, stamp):
     pc.height = 1
     pc.width = n
     pc.fields = [
-        PointField(name="x", offset=0, datatype=PointField.FLOAT32, count=1),
-        PointField(name="y", offset=4, datatype=PointField.FLOAT32, count=1),
-        PointField(name="z", offset=8, datatype=PointField.FLOAT32, count=1),
-        PointField(name="intensity", offset=12, datatype=PointField.FLOAT32, count=1),
+        PointField(name='x', offset=0, datatype=PointField.FLOAT32, count=1),
+        PointField(name='y', offset=4, datatype=PointField.FLOAT32, count=1),
+        PointField(name='z', offset=8, datatype=PointField.FLOAT32, count=1),
+        PointField(name='intensity', offset=12, datatype=PointField.FLOAT32, count=1),
     ]
     pc.is_bigendian = False
     pc.point_step = 16
@@ -89,7 +88,7 @@ def ros1_pc2_to_ros2(m):
     pc.point_step = int(m.point_step)
     pc.row_step = int(m.row_step)
     data = m.data
-    pc.data = data.tobytes() if hasattr(data, "tobytes") else bytes(data)
+    pc.data = data.tobytes() if hasattr(data, 'tobytes') else bytes(data)
     pc.is_dense = bool(m.is_dense)
     return pc
 
@@ -97,15 +96,15 @@ def ros1_pc2_to_ros2(m):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument(
-        "--in", dest="inp",
-        default=str(pathlib.Path.home() / "Downloads/Calibration.bag"))
-    ap.add_argument("--out", default=str(pathlib.Path.home() / "ros2_ws/bags/calibration_ros2"))
-    ap.add_argument("--limit", type=int, default=0, help="stop after N messages (debug)")
-    ap.add_argument("--accumulate", type=int, default=40,
-                    help="Livox sliding-window size (frames) to densify the "
-                         "non-repetitive solid-state scans and remove flicker")
-    ap.add_argument("--accum-stride", type=int, default=4,
-                    help="emit an accumulated Livox cloud every Nth input message")
+        '--in', dest='inp',
+        default=str(pathlib.Path.home() / 'Downloads/Calibration.bag'))
+    ap.add_argument('--out', default=str(pathlib.Path.home() / 'ros2_ws/bags/calibration_ros2'))
+    ap.add_argument('--limit', type=int, default=0, help='stop after N messages (debug)')
+    ap.add_argument('--accumulate', type=int, default=40,
+                    help='Livox sliding-window size (frames) to densify the '
+                         'non-repetitive solid-state scans and remove flicker')
+    ap.add_argument('--accum-stride', type=int, default=4,
+                    help='emit an accumulated Livox cloud every Nth input message')
     args = ap.parse_args()
 
     out = pathlib.Path(args.out)
@@ -116,16 +115,16 @@ def main():
     ts = get_typestore(Stores.ROS1_NOETIC)
 
     writer = rosbag2_py.SequentialWriter()
-    writer.open(rosbag2_py.StorageOptions(uri=str(out), storage_id="mcap"),
-                rosbag2_py.ConverterOptions("", ""))
+    writer.open(rosbag2_py.StorageOptions(uri=str(out), storage_id='mcap'),
+                rosbag2_py.ConverterOptions('', ''))
 
-    out_topics = ["/ouster/points", "/camera/depth/color/points",
-                  "/avia/points", "/mid360/points"]
+    out_topics = ['/ouster/points', '/camera/depth/color/points',
+                  '/avia/points', '/mid360/points']
     for t in out_topics:
         writer.create_topic(rosbag2_py.TopicMetadata(
-            name=t, type="sensor_msgs/msg/PointCloud2", serialization_format="cdr"))
+            name=t, type='sensor_msgs/msg/PointCloud2', serialization_format='cdr'))
 
-    counts = {t: 0 for t in out_topics}
+    counts = dict.fromkeys(out_topics, 0)
     # Sliding window of recent Livox frames per source: each non-repetitive
     # 100 Hz swath is a coherent spatial chunk that relocates every frame, so a
     # single swath flickers against the stable Ouster cloud. Accumulating the
@@ -137,7 +136,7 @@ def main():
 
     with Reader(pathlib.Path(args.inp)) as r:
         for c in r.connections:
-            if "CustomMsg" in c.msgtype:
+            if 'CustomMsg' in c.msgtype:
                 text = c.msgdef[1] if isinstance(c.msgdef, tuple) else c.msgdef
                 ts.register(get_types_from_msg(text, c.msgtype))
 
@@ -167,10 +166,10 @@ def main():
                 break
 
     del writer
-    print("wrote:", str(out))
+    print('wrote:', str(out))
     for t, n in counts.items():
-        print(f"  {t:28} {n}")
+        print(f'  {t:28} {n}')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/doc/media/prepare_bag.py
+++ b/doc/media/prepare_bag.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Prepare the TIERS Calibration.bag (ROS 1) as a clean ROS 2 mcap for polka.
+"""
+Prepare the TIERS Calibration.bag (ROS 1) as a clean ROS 2 mcap for polka.
 
 One pass over the ROS 1 bag:
   /ouster/points             (PointCloud2)                   -> passthrough
@@ -95,7 +96,9 @@ def ros1_pc2_to_ros2(m):
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--in", dest="inp", default=str(pathlib.Path.home() / "Downloads/Calibration.bag"))
+    ap.add_argument(
+        "--in", dest="inp",
+        default=str(pathlib.Path.home() / "Downloads/Calibration.bag"))
     ap.add_argument("--out", default=str(pathlib.Path.home() / "ros2_ws/bags/calibration_ros2"))
     ap.add_argument("--limit", type=int, default=0, help="stop after N messages (debug)")
     ap.add_argument("--accumulate", type=int, default=40,

--- a/doc/media/render_o3d.py
+++ b/doc/media/render_o3d.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Render per-feature demo panels with Open3D offscreen + matplotlib compositing.
+"""
+Render per-feature demo panels with Open3D offscreen + matplotlib compositing.
 
 Open3D's GPU offscreen renderer draws the point-cloud pixels (depth, AA); a thin
 matplotlib layer composes the divided panel with titles/labels. One panel = a
@@ -169,8 +170,12 @@ class Renderer:
 def scan_img(xy, lim=12.0):
     """Top-down 2D scan render via matplotlib, returned as an RGB array."""
     fig = plt.figure(figsize=(TILE / 100, TILE / 100), dpi=100, facecolor=BG[:3])
-    ax = fig.add_axes([0, 0, 1, 1]); ax.set_facecolor(BG[:3])
-    ax.set_xlim(-lim, lim); ax.set_ylim(-lim, lim); ax.set_aspect("equal"); ax.axis("off")
+    ax = fig.add_axes([0, 0, 1, 1])
+    ax.set_facecolor(BG[:3])
+    ax.set_xlim(-lim, lim)
+    ax.set_ylim(-lim, lim)
+    ax.set_aspect("equal")
+    ax.axis("off")
     if xy.shape[0] > 0:
         rr = np.hypot(xy[:, 0], xy[:, 1])
         ax.scatter(xy[:, 0], xy[:, 1], c=rr, cmap="turbo", s=6, linewidths=0)
@@ -188,7 +193,8 @@ def compose(imgL, imgR, title, labelL, labelR, footL, footR, out_png):
                  weight="bold", y=0.965)
     for i, (img, lab, foot) in enumerate([(imgL, labelL, footL), (imgR, labelR, footR)]):
         ax = fig.add_subplot(1, 2, i + 1)
-        ax.imshow(img); ax.axis("off")
+        ax.imshow(img)
+        ax.axis("off")
         ax.text(0.03, 0.95, lab, transform=ax.transAxes, color="white",
                 fontsize=20, family="monospace", weight="bold", va="top")
         ax.text(0.03, 0.04, foot, transform=ax.transAxes, color="#bbb",
@@ -258,7 +264,9 @@ def main():
     args = ap.parse_args()
 
     eye, center, up = compute_camera(args.work)
-    print(f"camera eye={[round(v,2) for v in eye]} center={[round(v,2) for v in center]}", flush=True)
+    eye_r = [round(v, 2) for v in eye]
+    center_r = [round(v, 2) for v in center]
+    print(f"camera eye={eye_r} center={center_r}", flush=True)
     renderer = Renderer(eye, center, up)
 
     names = [args.only] if args.only else list(PANELS.keys())

--- a/doc/media/render_o3d.py
+++ b/doc/media/render_o3d.py
@@ -13,21 +13,21 @@ left/right comparison of two captured polka runs (or cloud+scan for dual output)
 import argparse
 import pathlib
 
-import numpy as np
 import matplotlib
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt  # noqa: E402
+matplotlib.use('Agg')
 import matplotlib.cm as cm  # noqa: E402
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
 
 import open3d as o3d  # noqa: E402
 from open3d.visualization import rendering  # noqa: E402
 
 from rclpy.serialization import deserialize_message  # noqa: E402
-from rosbag2_py import SequentialReader, StorageOptions, ConverterOptions  # noqa: E402
-from sensor_msgs.msg import PointCloud2, LaserScan  # noqa: E402
+from rosbag2_py import ConverterOptions, SequentialReader, StorageOptions  # noqa: E402
+from sensor_msgs.msg import LaserScan, PointCloud2  # noqa: E402
 
-CLOUD_TOPIC = "/polka/merged_cloud"
-SCAN_TOPIC = "/polka/merged_scan"
+CLOUD_TOPIC = '/polka/merged_cloud'
+SCAN_TOPIC = '/polka/merged_scan'
 STAMP_TOL_NS = 60_000_000  # 60 ms
 
 TILE = 1100               # px per tile (square)
@@ -35,42 +35,42 @@ BG = (0.07, 0.07, 0.08, 1.0)
 POINT_SIZE = 2.6
 MAX_POINTS = 130000       # stride-subsample above this (speed; 1100px can't resolve more)
 ZCOLOR = (-1.5, 4.0)      # z range mapped to the colormap (output frame, os_sensor)
-CMAP = cm.get_cmap("turbo")
+CMAP = cm.get_cmap('turbo')
 
 # panel -> (layout, left_cfg, right_cfg, title, left_label, right_label)
 #   layout "cc" = cloud|cloud, "cs" = cloud|scan
 PANELS = {
-    "fusion":         ("cc", "single", "merged", "Multi-LiDAR fusion",
-                       "Ouster only", "Ouster + Avia + Mid-360 merged"),
-    "filter_range":   ("cc", "merged", "filter_range", "Output filter: range",
-                       "merged", "range 0.5-6 m"),
-    "filter_angular": ("cc", "merged", "filter_angular", "Output filter: angular",
-                       "merged", "keep +/-45 deg front"),
-    "filter_box":     ("cc", "merged", "filter_box", "Output filter: box",
-                       "merged", "+/-3 m AABB"),
-    "filter_height":  ("cc", "merged", "filter_height", "Output filter: height cap",
-                       "merged", "z in [-0.6, 1.0] m"),
-    "angular_invert": ("cc", "invert_keep", "invert_exclude", "Angular filter: invert flag",
-                       "keep +/-45 deg", "exclude +/-45 deg"),
-    "self_filter":    ("cc", "merged", "self_on", "Self / footprint filter",
-                       "no self-filter", "chassis box excluded"),
-    "voxel":          ("cc", "merged", "voxel_on", "Voxel downsample",
-                       "full density", "voxel leaf 0.2 m"),
-    "cpu_vs_cuda":    ("cc", "cpu", "merged", "CPU vs CUDA pipeline",
-                       "CPU path", "CUDA path"),
-    "dual_output":    ("cs", "dual", "dual", "Dual output: cloud + scan",
-                       "merged_cloud (3D)", "merged_scan (2D top-down)"),
+    'fusion':         ('cc', 'single', 'merged', 'Multi-LiDAR fusion',
+                       'Ouster only', 'Ouster + Avia + Mid-360 merged'),
+    'filter_range':   ('cc', 'merged', 'filter_range', 'Output filter: range',
+                       'merged', 'range 0.5-6 m'),
+    'filter_angular': ('cc', 'merged', 'filter_angular', 'Output filter: angular',
+                       'merged', 'keep +/-45 deg front'),
+    'filter_box':     ('cc', 'merged', 'filter_box', 'Output filter: box',
+                       'merged', '+/-3 m AABB'),
+    'filter_height':  ('cc', 'merged', 'filter_height', 'Output filter: height cap',
+                       'merged', 'z in [-0.6, 1.0] m'),
+    'angular_invert': ('cc', 'invert_keep', 'invert_exclude', 'Angular filter: invert flag',
+                       'keep +/-45 deg', 'exclude +/-45 deg'),
+    'self_filter':    ('cc', 'merged', 'self_on', 'Self / footprint filter',
+                       'no self-filter', 'chassis box excluded'),
+    'voxel':          ('cc', 'merged', 'voxel_on', 'Voxel downsample',
+                       'full density', 'voxel leaf 0.2 m'),
+    'cpu_vs_cuda':    ('cc', 'cpu', 'merged', 'CPU vs CUDA pipeline',
+                       'CPU path', 'CUDA path'),
+    'dual_output':    ('cs', 'dual', 'dual', 'Dual output: cloud + scan',
+                       'merged_cloud (3D)', 'merged_scan (2D top-down)'),
 }
 
 
 def _bag_dir(work, cfg):
-    d = work / f"cap_{cfg}" / "run"
-    return d if d.is_dir() else work / f"cap_{cfg}"
+    d = work / f'cap_{cfg}' / 'run'
+    return d if d.is_dir() else work / f'cap_{cfg}'
 
 
 def _reader(bag_dir):
     r = SequentialReader()
-    r.open(StorageOptions(uri=str(bag_dir), storage_id="mcap"), ConverterOptions("", ""))
+    r.open(StorageOptions(uri=str(bag_dir), storage_id='mcap'), ConverterOptions('', ''))
     return r
 
 
@@ -83,9 +83,9 @@ def pc2_xyz(msg):
         f = fields[name]
         return np.frombuffer(raw[:, f.offset:f.offset + 4].tobytes(), dtype=np.float32)
 
-    if not {"x", "y", "z"}.issubset(fields):
+    if not {'x', 'y', 'z'}.issubset(fields):
         return np.zeros((0, 3), np.float32)
-    return np.stack([col("x"), col("y"), col("z")], axis=1)
+    return np.stack([col('x'), col('y'), col('z')], axis=1)
 
 
 def read_clouds(bag_dir):
@@ -141,12 +141,13 @@ def align(stream_a, stream_b):
 
 
 class Renderer:
+
     def __init__(self, eye, center, up, fov=55.0):
         self.r = rendering.OffscreenRenderer(TILE, TILE)
         self.r.scene.set_background(list(BG))
         self.r.scene.scene.set_sun_light([0.3, 0.3, -1.0], [1, 1, 1], 60000)
         self.mat = rendering.MaterialRecord()
-        self.mat.shader = "defaultUnlit"
+        self.mat.shader = 'defaultUnlit'
         self.mat.point_size = POINT_SIZE
         self.eye, self.center, self.up, self.fov = eye, center, up, fov
 
@@ -159,7 +160,7 @@ class Renderer:
             pc.points = o3d.utility.Vector3dVector(xyz.astype(np.float64))
             t = np.clip((xyz[:, 2] - ZCOLOR[0]) / (ZCOLOR[1] - ZCOLOR[0]), 0, 1)
             pc.colors = o3d.utility.Vector3dVector(CMAP(t)[:, :3])
-            self.r.scene.add_geometry("pc", pc, self.mat)
+            self.r.scene.add_geometry('pc', pc, self.mat)
         self.r.setup_camera(self.fov,
                             np.asarray(self.center, np.float32),
                             np.asarray(self.eye, np.float32),
@@ -174,12 +175,12 @@ def scan_img(xy, lim=12.0):
     ax.set_facecolor(BG[:3])
     ax.set_xlim(-lim, lim)
     ax.set_ylim(-lim, lim)
-    ax.set_aspect("equal")
-    ax.axis("off")
+    ax.set_aspect('equal')
+    ax.axis('off')
     if xy.shape[0] > 0:
         rr = np.hypot(xy[:, 0], xy[:, 1])
-        ax.scatter(xy[:, 0], xy[:, 1], c=rr, cmap="turbo", s=6, linewidths=0)
-    ax.plot(0, 0, marker="^", color="white", markersize=16)
+        ax.scatter(xy[:, 0], xy[:, 1], c=rr, cmap='turbo', s=6, linewidths=0)
+    ax.plot(0, 0, marker='^', color='white', markersize=16)
     fig.canvas.draw()
     w, h = fig.canvas.get_width_height()
     buf = np.frombuffer(fig.canvas.buffer_rgba(), np.uint8).reshape(h, w, 4)[:, :, :3].copy()
@@ -189,18 +190,18 @@ def scan_img(xy, lim=12.0):
 
 def compose(imgL, imgR, title, labelL, labelR, footL, footR, out_png):
     fig = plt.figure(figsize=(19.2, 10.0), dpi=100, facecolor=BG[:3])
-    fig.suptitle(title, color="white", fontsize=30, family="monospace",
-                 weight="bold", y=0.965)
+    fig.suptitle(title, color='white', fontsize=30, family='monospace',
+                 weight='bold', y=0.965)
     for i, (img, lab, foot) in enumerate([(imgL, labelL, footL), (imgR, labelR, footR)]):
         ax = fig.add_subplot(1, 2, i + 1)
         ax.imshow(img)
-        ax.axis("off")
-        ax.text(0.03, 0.95, lab, transform=ax.transAxes, color="white",
-                fontsize=20, family="monospace", weight="bold", va="top")
-        ax.text(0.03, 0.04, foot, transform=ax.transAxes, color="#bbb",
-                fontsize=15, family="monospace")
-    fig.text(0.99, 0.015, "polka", color="#666", fontsize=15, family="monospace",
-             ha="right", weight="bold")
+        ax.axis('off')
+        ax.text(0.03, 0.95, lab, transform=ax.transAxes, color='white',
+                fontsize=20, family='monospace', weight='bold', va='top')
+        ax.text(0.03, 0.04, foot, transform=ax.transAxes, color='#bbb',
+                fontsize=15, family='monospace')
+    fig.text(0.99, 0.015, 'polka', color='#666', fontsize=15, family='monospace',
+             ha='right', weight='bold')
     fig.subplots_adjust(left=0.005, right=0.995, top=0.92, bottom=0.01, wspace=0.01)
     fig.savefig(out_png, facecolor=BG[:3])
     plt.close(fig)
@@ -208,7 +209,7 @@ def compose(imgL, imgR, title, labelL, labelR, footL, footR, out_png):
 
 def compute_camera(work):
     """Pick a fixed 3/4 view from the merged cloud's horizontal extent."""
-    clouds = read_clouds(_bag_dir(work, "merged"))
+    clouds = read_clouds(_bag_dir(work, 'merged'))
     pts = np.concatenate([c for _, c in clouds[:5]], axis=0) if clouds else np.zeros((1, 3))
     lo = np.percentile(pts, 2, axis=0)
     hi = np.percentile(pts, 98, axis=0)
@@ -224,49 +225,49 @@ def render_panel(name, work, out, renderer):
     layout, lcfg, rcfg, title, llab, rlab = PANELS[name]
     out_dir = out / name
     out_dir.mkdir(parents=True, exist_ok=True)
-    for old in out_dir.glob("f_*.png"):  # clear stale frames from a previous run
+    for old in out_dir.glob('f_*.png'):  # clear stale frames from a previous run
         old.unlink()
 
-    if layout == "cc":
+    if layout == 'cc':
         L = read_clouds(_bag_dir(work, lcfg))
         R = read_clouds(_bag_dir(work, rcfg))
         pairs = list(align(L, R))
-        print(f"[{name}] {lcfg}={len(L)} {rcfg}={len(R)} aligned={len(pairs)}", flush=True)
+        print(f'[{name}] {lcfg}={len(L)} {rcfg}={len(R)} aligned={len(pairs)}', flush=True)
         for i, (a, b) in enumerate(pairs):
             imgL = renderer.cloud_img(a)
             imgR = renderer.cloud_img(b)
             compose(imgL, imgR, title, llab, rlab,
-                    f"{a.shape[0]:,} pts", f"{b.shape[0]:,} pts",
-                    out_dir / f"f_{i:04d}.png")
+                    f'{a.shape[0]:,} pts', f'{b.shape[0]:,} pts',
+                    out_dir / f'f_{i:04d}.png')
         return len(pairs)
 
     # cloud | scan from the same dual capture
     C = read_clouds(_bag_dir(work, lcfg))
     S = read_scans(_bag_dir(work, rcfg))
     pairs = list(align(C, S))
-    print(f"[{name}] cloud={len(C)} scan={len(S)} aligned={len(pairs)}", flush=True)
+    print(f'[{name}] cloud={len(C)} scan={len(S)} aligned={len(pairs)}', flush=True)
     for i, (c, s) in enumerate(pairs):
         imgL = renderer.cloud_img(c)
         imgR = scan_img(s)
         compose(imgL, imgR, title, llab, rlab,
-                f"{c.shape[0]:,} pts", f"{s.shape[0]:,} beams",
-                out_dir / f"f_{i:04d}.png")
+                f'{c.shape[0]:,} pts', f'{s.shape[0]:,} beams',
+                out_dir / f'f_{i:04d}.png')
     return len(pairs)
 
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--work", type=pathlib.Path,
-                    default=pathlib.Path(__file__).parent / "work")
-    ap.add_argument("--out", type=pathlib.Path,
-                    default=pathlib.Path(__file__).parent / "frames")
-    ap.add_argument("--only", default=None)
+    ap.add_argument('--work', type=pathlib.Path,
+                    default=pathlib.Path(__file__).parent / 'work')
+    ap.add_argument('--out', type=pathlib.Path,
+                    default=pathlib.Path(__file__).parent / 'frames')
+    ap.add_argument('--only', default=None)
     args = ap.parse_args()
 
     eye, center, up = compute_camera(args.work)
     eye_r = [round(v, 2) for v in eye]
     center_r = [round(v, 2) for v in center]
-    print(f"camera eye={eye_r} center={center_r}", flush=True)
+    print(f'camera eye={eye_r} center={center_r}', flush=True)
     renderer = Renderer(eye, center, up)
 
     names = [args.only] if args.only else list(PANELS.keys())
@@ -274,5 +275,5 @@ def main():
         render_panel(name, args.work, args.out, renderer)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/doc/media/render_scan.py
+++ b/doc/media/render_scan.py
@@ -16,23 +16,23 @@ bag is near-stationary, so index pairing is sufficient).
 import argparse
 import pathlib
 
-import numpy as np
 import matplotlib
-matplotlib.use("Agg")
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
 
 from rclpy.serialization import deserialize_message  # noqa: E402
-from rosbag2_py import SequentialReader, StorageOptions, ConverterOptions  # noqa: E402
+from rosbag2_py import ConverterOptions, SequentialReader, StorageOptions  # noqa: E402
 from sensor_msgs.msg import LaserScan  # noqa: E402
 
-SCAN_TOPIC = "/polka/merged_scan"
-BG = "#121214"
+SCAN_TOPIC = '/polka/merged_scan'
+BG = '#121214'
 LIM = 6.5
 PT = 9
 # fixed order -> stable colour mapping / winner index
-SOURCES = [("ouster_scan", "Ouster", "#2bd4d4"),
-           ("avia_scan", "Avia", "#ff9a3c"),
-           ("mid360_scan", "Mid-360", "#7CFC54")]
+SOURCES = [('ouster_scan', 'Ouster', '#2bd4d4'),
+           ('avia_scan', 'Avia', '#ff9a3c'),
+           ('mid360_scan', 'Mid-360', '#7CFC54')]
 COLORS = [c for _, _, c in SOURCES]
 
 
@@ -43,11 +43,11 @@ def read_scan_ranges(run_dir):
     Returns (frames, angle_min, angle_increment), where frames is a list of
     per-frame range arrays with NaN for invalid bins.
     """
-    d = run_dir / "run"
+    d = run_dir / 'run'
     if not d.is_dir():
         d = run_dir
     r = SequentialReader()
-    r.open(StorageOptions(uri=str(d), storage_id="mcap"), ConverterOptions("", ""))
+    r.open(StorageOptions(uri=str(d), storage_id='mcap'), ConverterOptions('', ''))
     frames, amin, ainc = [], None, None
     while r.has_next():
         topic, data, _ = r.read_next()
@@ -67,31 +67,31 @@ def style(ax, title):
     ax.set_facecolor(BG)
     ax.set_xlim(-LIM, LIM)
     ax.set_ylim(-LIM, LIM)
-    ax.set_aspect("equal")
+    ax.set_aspect('equal')
     ax.set_xticks([])
     ax.set_yticks([])
     for s in ax.spines.values():
-        s.set_color("#333")
-    ax.plot(0, 0, marker="^", color="white", markersize=15, zorder=5)
-    ax.text(0.03, 0.96, title, transform=ax.transAxes, color="white",
-            fontsize=20, family="monospace", weight="bold", va="top")
+        s.set_color('#333')
+    ax.plot(0, 0, marker='^', color='white', markersize=15, zorder=5)
+    ax.text(0.03, 0.96, title, transform=ax.transAxes, color='white',
+            fontsize=20, family='monospace', weight='bold', va='top')
 
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--work", type=pathlib.Path,
-                    default=pathlib.Path(__file__).parent / "work")
-    ap.add_argument("--out", type=pathlib.Path,
-                    default=pathlib.Path(__file__).parent / "frames" / "scan_merge")
+    ap.add_argument('--work', type=pathlib.Path,
+                    default=pathlib.Path(__file__).parent / 'work')
+    ap.add_argument('--out', type=pathlib.Path,
+                    default=pathlib.Path(__file__).parent / 'frames' / 'scan_merge')
     args = ap.parse_args()
     args.out.mkdir(parents=True, exist_ok=True)
-    for old in args.out.glob("f_*.png"):
+    for old in args.out.glob('f_*.png'):
         old.unlink()
 
     srcs = []
     amin = ainc = None
     for cfg, label, color in SOURCES:
-        frames, am, ai = read_scan_ranges(args.work / f"cap_{cfg}")
+        frames, am, ai = read_scan_ranges(args.work / f'cap_{cfg}')
         srcs.append((label, color, frames))
         amin, ainc = am, ai
 
@@ -99,30 +99,30 @@ def main():
     nbins = len(srcs[0][2][0])
     ang = amin + np.arange(nbins) * ainc
     cos, sin = np.cos(ang), np.sin(ang)
-    print(f"frames -> {n}, bins={nbins}", flush=True)
+    print(f'frames -> {n}, bins={nbins}', flush=True)
 
     for i in range(n):
         # (3, nbins) range matrix, NaN where a source has no return
         R = np.vstack([srcs[k][2][i] for k in range(3)])
         fig = plt.figure(figsize=(19.2, 10.0), dpi=100, facecolor=BG)
-        fig.suptitle("2D LaserScan merge:  nearest return per direction wins",
-                     color="white", fontsize=28, family="monospace",
-                     weight="bold", y=0.965)
+        fig.suptitle('2D LaserScan merge:  nearest return per direction wins',
+                     color='white', fontsize=28, family='monospace',
+                     weight='bold', y=0.965)
 
         # Left: each sensor's full scan overlaid, alpha-blended so overlapping
         # coverage shows as a mix instead of whichever colour is drawn last.
         axL = fig.add_subplot(1, 2, 1)
-        style(axL, "individual scans")
+        style(axL, 'individual scans')
         for k, (label, color, _) in enumerate(srcs):
             v = np.isfinite(R[k])
             axL.scatter(R[k][v] * cos[v], R[k][v] * sin[v], s=PT, c=color,
                         linewidths=0, alpha=0.5)
-            axL.text(0.03, 0.90 - 0.05 * k, f"■ {label}", transform=axL.transAxes,
-                     color=color, fontsize=16, family="monospace", weight="bold")
+            axL.text(0.03, 0.90 - 0.05 * k, f'■ {label}', transform=axL.transAxes,
+                     color=color, fontsize=16, family='monospace', weight='bold')
 
         # Right: merged = nearest per bin, colored by the winning sensor
         axR = fig.add_subplot(1, 2, 2)
-        style(axR, "merged scan  (nearest return wins)")
+        style(axR, 'merged scan  (nearest return wins)')
         anyvalid = np.isfinite(R).any(axis=0)
         Rfill = np.where(np.isfinite(R), R, np.inf)
         winner = np.argmin(Rfill, axis=0)
@@ -136,17 +136,17 @@ def main():
         tot = max(1, sum(w[2] for w in wins))
         x0 = 0.03
         for label, color, c in wins:
-            axR.text(x0, 0.05, f"{label} {round(100*c/tot)}%", transform=axR.transAxes,
-                     color=color, fontsize=15, family="monospace", weight="bold")
+            axR.text(x0, 0.05, f'{label} {round(100*c/tot)}%', transform=axR.transAxes,
+                     color=color, fontsize=15, family='monospace', weight='bold')
             x0 += 0.013 * (len(label) + 5)
 
-        fig.text(0.99, 0.015, "polka", color="#666", fontsize=15,
-                 family="monospace", ha="right", weight="bold")
+        fig.text(0.99, 0.015, 'polka', color='#666', fontsize=15,
+                 family='monospace', ha='right', weight='bold')
         fig.subplots_adjust(left=0.01, right=0.99, top=0.92, bottom=0.01, wspace=0.02)
-        fig.savefig(args.out / f"f_{i:04d}.png", facecolor=BG)
+        fig.savefig(args.out / f'f_{i:04d}.png', facecolor=BG)
         plt.close(fig)
-    print(f"wrote {n} frames to {args.out}", flush=True)
+    print(f'wrote {n} frames to {args.out}', flush=True)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/doc/media/render_scan.py
+++ b/doc/media/render_scan.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Render the 2D LaserScan merge panel.
+"""
+Render the 2D LaserScan merge panel.
 
 Left:  each lidar's own flattened scan, overlaid and color-coded.
 Right: the merged scan, where every beam is colored by the sensor that *won*
@@ -36,8 +37,12 @@ COLORS = [c for _, _, c in SOURCES]
 
 
 def read_scan_ranges(run_dir):
-    """Return (list of per-frame range arrays with NaN for invalid bins,
-    angle_min, angle_increment)."""
+    """
+    Return per-frame range arrays plus scan geometry.
+
+    Returns (frames, angle_min, angle_increment), where frames is a list of
+    per-frame range arrays with NaN for invalid bins.
+    """
     d = run_dir / "run"
     if not d.is_dir():
         d = run_dir
@@ -60,8 +65,11 @@ def read_scan_ranges(run_dir):
 
 def style(ax, title):
     ax.set_facecolor(BG)
-    ax.set_xlim(-LIM, LIM); ax.set_ylim(-LIM, LIM); ax.set_aspect("equal")
-    ax.set_xticks([]); ax.set_yticks([])
+    ax.set_xlim(-LIM, LIM)
+    ax.set_ylim(-LIM, LIM)
+    ax.set_aspect("equal")
+    ax.set_xticks([])
+    ax.set_yticks([])
     for s in ax.spines.values():
         s.set_color("#333")
     ax.plot(0, 0, marker="^", color="white", markersize=15, zorder=5)

--- a/doc/media/run_capture.py
+++ b/doc/media/run_capture.py
@@ -22,10 +22,10 @@ import time
 import psutil
 import rclpy
 from rclpy.node import Node
-from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
 from rclpy.serialization import serialize_message
-from sensor_msgs.msg import PointCloud2, LaserScan
 import rosbag2_py
+from sensor_msgs.msg import LaserScan, PointCloud2
 
 try:
     import pynvml
@@ -36,10 +36,10 @@ except Exception:
     _HAS_GPU = False
 
 HERE = pathlib.Path(__file__).parent
-LAUNCH_FILE = HERE / "demo_bringup.launch.py"
-CLOUD_TOPIC = "/polka/merged_cloud"
-SCAN_TOPIC = "/polka/merged_scan"
-DEFAULT_BAG = pathlib.Path.home() / "ros2_ws/bags/calibration_ros2"
+LAUNCH_FILE = HERE / 'demo_bringup.launch.py'
+CLOUD_TOPIC = '/polka/merged_cloud'
+SCAN_TOPIC = '/polka/merged_scan'
+DEFAULT_BAG = pathlib.Path.home() / 'ros2_ws/bags/calibration_ros2'
 
 
 def _reliable(depth=10):
@@ -50,19 +50,20 @@ def _reliable(depth=10):
 
 
 class CaptureNode(Node):
+
     def __init__(self, run_dir):
-        super().__init__("polka_capture_probe")
+        super().__init__('polka_capture_probe')
         self.set_parameters([rclpy.parameter.Parameter(
-            "use_sim_time", rclpy.parameter.Parameter.Type.BOOL, True)])
+            'use_sim_time', rclpy.parameter.Parameter.Type.BOOL, True)])
         self.latencies_ms = []
 
         self.writer = rosbag2_py.SequentialWriter()
-        self.writer.open(rosbag2_py.StorageOptions(uri=str(run_dir), storage_id="mcap"),
-                         rosbag2_py.ConverterOptions("", ""))
+        self.writer.open(rosbag2_py.StorageOptions(uri=str(run_dir), storage_id='mcap'),
+                         rosbag2_py.ConverterOptions('', ''))
         self.writer.create_topic(rosbag2_py.TopicMetadata(
-            name=CLOUD_TOPIC, type="sensor_msgs/msg/PointCloud2", serialization_format="cdr"))
+            name=CLOUD_TOPIC, type='sensor_msgs/msg/PointCloud2', serialization_format='cdr'))
         self.writer.create_topic(rosbag2_py.TopicMetadata(
-            name=SCAN_TOPIC, type="sensor_msgs/msg/LaserScan", serialization_format="cdr"))
+            name=SCAN_TOPIC, type='sensor_msgs/msg/LaserScan', serialization_format='cdr'))
 
         self.create_subscription(PointCloud2, CLOUD_TOPIC, self._cloud_cb, _reliable())
         self.create_subscription(LaserScan, SCAN_TOPIC, self._scan_cb, _reliable())
@@ -119,7 +120,7 @@ def find_polka_pid(parent_pid, timeout=12.0):
         try:
             for child in psutil.Process(parent_pid).children(recursive=True):
                 try:
-                    if "polka_node" in " ".join(child.cmdline()):
+                    if 'polka_node' in ' '.join(child.cmdline()):
                         return child.pid
                 except (psutil.NoSuchProcess, psutil.AccessDenied):
                     continue
@@ -150,30 +151,30 @@ def kill_tree(pid):
 
 def run_once(config_yaml, out_dir, bag_path, duration, warmup=3.0):
     out_dir.mkdir(parents=True, exist_ok=True)
-    run_dir = out_dir / "run"
+    run_dir = out_dir / 'run'
     if run_dir.exists():
         import shutil
         shutil.rmtree(run_dir)
 
     polka_proc = subprocess.Popen(
-        ["ros2", "launch", str(LAUNCH_FILE), f"config_file:={config_yaml}"],
-        stdout=open(out_dir / "polka.log", "w"), stderr=subprocess.STDOUT,
+        ['ros2', 'launch', str(LAUNCH_FILE), f'config_file:={config_yaml}'],
+        stdout=open(out_dir / 'polka.log', 'w'), stderr=subprocess.STDOUT,
         preexec_fn=os.setsid)
     polka_node_pid = find_polka_pid(polka_proc.pid)
     if polka_node_pid is None:
         print(f"  ERROR: polka_node didn't appear under {polka_proc.pid}", flush=True)
         kill_tree(polka_proc.pid)
         return None
-    print(f"  polka_node pid={polka_node_pid}", flush=True)
+    print(f'  polka_node pid={polka_node_pid}', flush=True)
 
     rclpy.init()
     node = CaptureNode(run_dir)
 
     time.sleep(1.0)  # let polka settle / TFs latch before playback
     play_proc = subprocess.Popen(
-        ["ros2", "bag", "play", str(bag_path), "--clock",
-         "--read-ahead-queue-size", "2000"],
-        stdout=open(out_dir / "play.log", "w"), stderr=subprocess.STDOUT,
+        ['ros2', 'bag', 'play', str(bag_path), '--clock',
+         '--read-ahead-queue-size', '2000'],
+        stdout=open(out_dir / 'play.log', 'w'), stderr=subprocess.STDOUT,
         preexec_fn=os.setsid)
 
     stop_evt = threading.Event()
@@ -205,39 +206,39 @@ def run_once(config_yaml, out_dir, bag_path, duration, warmup=3.0):
     rss_mb = rss_mb[int(warmup):]
     gpu_pct = gpu_pct[int(warmup):]
 
-    metrics = {"config": str(config_yaml), "latency_ms": latencies,
-               "cpu_pct": cpu_pct, "rss_mb": rss_mb, "gpu_pct": gpu_pct,
-               "n_msgs": len(latencies), "duration_s": duration, "warmup_s": warmup}
-    with open(out_dir / "metrics.json", "w") as f:
+    metrics = {'config': str(config_yaml), 'latency_ms': latencies,
+               'cpu_pct': cpu_pct, 'rss_mb': rss_mb, 'gpu_pct': gpu_pct,
+               'n_msgs': len(latencies), 'duration_s': duration, 'warmup_s': warmup}
+    with open(out_dir / 'metrics.json', 'w') as f:
         json.dump(metrics, f, indent=2)
 
     print(
-        f"  metrics: n_lat={len(latencies)} n_cpu={len(cpu_pct)} n_gpu={len(gpu_pct)}",
+        f'  metrics: n_lat={len(latencies)} n_cpu={len(cpu_pct)} n_gpu={len(gpu_pct)}',
         flush=True)
     if not latencies:
-        print("  WARN: no merged_cloud messages received", flush=True)
+        print('  WARN: no merged_cloud messages received', flush=True)
         return None
     return metrics
 
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("config_yaml", type=pathlib.Path)
-    ap.add_argument("out_dir", type=pathlib.Path)
-    ap.add_argument("--bag", type=pathlib.Path, default=DEFAULT_BAG)
-    ap.add_argument("--duration", type=float, default=11.0)
-    ap.add_argument("--warmup", type=float, default=2.0)
-    ap.add_argument("--repeats", type=int, default=1)
+    ap.add_argument('config_yaml', type=pathlib.Path)
+    ap.add_argument('out_dir', type=pathlib.Path)
+    ap.add_argument('--bag', type=pathlib.Path, default=DEFAULT_BAG)
+    ap.add_argument('--duration', type=float, default=11.0)
+    ap.add_argument('--warmup', type=float, default=2.0)
+    ap.add_argument('--repeats', type=int, default=1)
     args = ap.parse_args()
 
     if args.repeats == 1:
         run_once(args.config_yaml, args.out_dir, args.bag, args.duration, args.warmup)
     else:
         for i in range(args.repeats):
-            sub = args.out_dir / f"rep_{i:02d}"
-            print(f"== repeat {i+1}/{args.repeats} -> {sub} ==", flush=True)
+            sub = args.out_dir / f'rep_{i:02d}'
+            print(f'== repeat {i+1}/{args.repeats} -> {sub} ==', flush=True)
             run_once(args.config_yaml, sub, args.bag, args.duration, args.warmup)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()

--- a/doc/media/run_capture.py
+++ b/doc/media/run_capture.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Capture one polka run: output bag + performance metrics sidecar.
+"""
+Capture one polka run: output bag + performance metrics sidecar.
 
 Launches demo_bringup.launch.py (polka_node + static TFs) with a config, plays
 the converted calibration bag, samples CPU/RAM/GPU + end-to-end latency, and
@@ -178,9 +179,11 @@ def run_once(config_yaml, out_dir, bag_path, duration, warmup=3.0):
     stop_evt = threading.Event()
     cpu_pct, rss_mb, gpu_pct = [], [], []
     proc = psutil.Process(polka_node_pid)
-    th_cpu = threading.Thread(target=sample_psutil, args=(proc, stop_evt, cpu_pct, rss_mb), daemon=True)
+    th_cpu = threading.Thread(
+        target=sample_psutil, args=(proc, stop_evt, cpu_pct, rss_mb), daemon=True)
     th_gpu = threading.Thread(target=sample_gpu, args=(stop_evt, gpu_pct), daemon=True)
-    th_cpu.start(); th_gpu.start()
+    th_cpu.start()
+    th_gpu.start()
 
     end_time = time.monotonic() + duration
     while time.monotonic() < end_time:
@@ -189,7 +192,8 @@ def run_once(config_yaml, out_dir, bag_path, duration, warmup=3.0):
     stop_evt.set()
     kill_tree(play_proc.pid)
     kill_tree(polka_proc.pid)
-    th_cpu.join(timeout=2); th_gpu.join(timeout=2)
+    th_cpu.join(timeout=2)
+    th_gpu.join(timeout=2)
 
     latencies = node.latencies_ms[:]
     node.close()
@@ -207,7 +211,9 @@ def run_once(config_yaml, out_dir, bag_path, duration, warmup=3.0):
     with open(out_dir / "metrics.json", "w") as f:
         json.dump(metrics, f, indent=2)
 
-    print(f"  metrics: n_lat={len(latencies)} n_cpu={len(cpu_pct)} n_gpu={len(gpu_pct)}", flush=True)
+    print(
+        f"  metrics: n_lat={len(latencies)} n_cpu={len(cpu_pct)} n_gpu={len(gpu_pct)}",
+        flush=True)
     if not latencies:
         print("  WARN: no merged_cloud messages received", flush=True)
         return None

--- a/include/polka/config/config_loader.hpp
+++ b/include/polka/config/config_loader.hpp
@@ -12,15 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__CONFIG__CONFIG_LOADER_HPP
-#define POLKA__CONFIG__CONFIG_LOADER_HPP
+#ifndef POLKA__CONFIG__CONFIG_LOADER_HPP_
+#define POLKA__CONFIG__CONFIG_LOADER_HPP_
+
+#include <string>
+#include <vector>
 
 #include "polka/types.hpp"
 #include <rclcpp/rclcpp.hpp>
 
-namespace polka {
+namespace polka
+{
 
-class ConfigLoader {
+class ConfigLoader
+{
 public:
   explicit ConfigLoader(rclcpp::Node * node);
   MergeConfig load();
@@ -40,4 +45,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__CONFIG__CONFIG_LOADER_HPP
+#endif  // POLKA__CONFIG__CONFIG_LOADER_HPP_

--- a/include/polka/filters/angular_filter.hpp
+++ b/include/polka/filters/angular_filter.hpp
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__FILTERS__ANGULAR_FILTER_HPP
-#define POLKA__FILTERS__ANGULAR_FILTER_HPP
+#ifndef POLKA__FILTERS__ANGULAR_FILTER_HPP_
+#define POLKA__FILTERS__ANGULAR_FILTER_HPP_
 
-#include "polka/filters/i_filter.hpp"
+#include <string>
 #include <vector>
 #include <utility>
 
-namespace polka {
+#include "polka/filters/i_filter.hpp"
 
-class AngularFilter : public IFilter {
+namespace polka
+{
+
+class AngularFilter : public IFilter
+{
 public:
   AngularFilter(const std::vector<std::pair<double, double>> & ranges_deg, bool invert);
   void apply(CloudT & cloud, const std::string & frame_id) override;
@@ -34,4 +38,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__FILTERS__ANGULAR_FILTER_HPP
+#endif  // POLKA__FILTERS__ANGULAR_FILTER_HPP_

--- a/include/polka/filters/box_filter.hpp
+++ b/include/polka/filters/box_filter.hpp
@@ -12,18 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__FILTERS__BOX_FILTER_HPP
-#define POLKA__FILTERS__BOX_FILTER_HPP
+#ifndef POLKA__FILTERS__BOX_FILTER_HPP_
+#define POLKA__FILTERS__BOX_FILTER_HPP_
 
-#include "polka/filters/i_filter.hpp"
 #include <Eigen/Core>
 
-namespace polka {
+#include <string>
 
-class BoxFilter : public IFilter {
+#include "polka/filters/i_filter.hpp"
+
+namespace polka
+{
+
+class BoxFilter : public IFilter
+{
 public:
-  BoxFilter(const Eigen::Vector3d & box_min, const Eigen::Vector3d & box_max,
-            bool invert = false);
+  BoxFilter(
+    const Eigen::Vector3d & box_min, const Eigen::Vector3d & box_max,
+    bool invert = false);
   void apply(CloudT & cloud, const std::string & frame_id) override;
 
 private:
@@ -33,4 +39,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__FILTERS__BOX_FILTER_HPP
+#endif  // POLKA__FILTERS__BOX_FILTER_HPP_

--- a/include/polka/filters/filter_chain.hpp
+++ b/include/polka/filters/filter_chain.hpp
@@ -15,28 +15,32 @@
 #ifndef POLKA__FILTERS__FILTER_CHAIN_HPP_
 #define POLKA__FILTERS__FILTER_CHAIN_HPP_
 
+#include <memory>
+#include <vector>
+
 #include "polka/types.hpp"
 #include "polka/filters/i_filter.hpp"
 #include "polka/filters/range_filter.hpp"
 #include "polka/filters/angular_filter.hpp"
 #include "polka/filters/box_filter.hpp"
 
-#include <memory>
-#include <vector>
-
-namespace polka {
+namespace polka
+{
 
 /// Build a filter chain from a FilterParams config.
 /// Returns an ordered vector: range → angular → box (enabled filters only).
 inline std::vector<std::unique_ptr<IFilter>> build_filter_chain(const FilterParams & fp)
 {
   std::vector<std::unique_ptr<IFilter>> chain;
-  if (fp.range_filter_enabled)
+  if (fp.range_filter_enabled) {
     chain.push_back(std::make_unique<RangeFilter>(fp.min_range, fp.max_range));
-  if (fp.angular_filter_enabled && !fp.angular_ranges.empty())
+  }
+  if (fp.angular_filter_enabled && !fp.angular_ranges.empty()) {
     chain.push_back(std::make_unique<AngularFilter>(fp.angular_ranges, fp.angular_invert));
-  if (fp.box_filter_enabled)
+  }
+  if (fp.box_filter_enabled) {
     chain.push_back(std::make_unique<BoxFilter>(fp.box_min, fp.box_max));
+  }
   return chain;
 }
 

--- a/include/polka/filters/i_filter.hpp
+++ b/include/polka/filters/i_filter.hpp
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__FILTERS__I_FILTER_HPP
-#define POLKA__FILTERS__I_FILTER_HPP
+#ifndef POLKA__FILTERS__I_FILTER_HPP_
+#define POLKA__FILTERS__I_FILTER_HPP_
 
-#include "polka/types.hpp"
 #include <string>
 
-namespace polka {
+#include "polka/types.hpp"
 
-class IFilter {
+namespace polka
+{
+
+class IFilter
+{
 public:
   virtual void apply(CloudT & cloud, const std::string & frame_id) = 0;
   virtual ~IFilter() = default;
@@ -28,4 +31,4 @@ public:
 
 }  // namespace polka
 
-#endif  // POLKA__FILTERS__I_FILTER_HPP
+#endif  // POLKA__FILTERS__I_FILTER_HPP_

--- a/include/polka/filters/range_filter.hpp
+++ b/include/polka/filters/range_filter.hpp
@@ -12,14 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__FILTERS__RANGE_FILTER_HPP
-#define POLKA__FILTERS__RANGE_FILTER_HPP
+#ifndef POLKA__FILTERS__RANGE_FILTER_HPP_
+#define POLKA__FILTERS__RANGE_FILTER_HPP_
+
+#include <string>
 
 #include "polka/filters/i_filter.hpp"
 
-namespace polka {
+namespace polka
+{
 
-class RangeFilter : public IFilter {
+class RangeFilter : public IFilter
+{
 public:
   RangeFilter(double min_range, double max_range);
   void apply(CloudT & cloud, const std::string & frame_id) override;
@@ -31,4 +35,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__FILTERS__RANGE_FILTER_HPP
+#endif  // POLKA__FILTERS__RANGE_FILTER_HPP_

--- a/include/polka/input/imu_buffer.hpp
+++ b/include/polka/input/imu_buffer.hpp
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__INPUT__IMU_BUFFER_HPP
-#define POLKA__INPUT__IMU_BUFFER_HPP
+#ifndef POLKA__INPUT__IMU_BUFFER_HPP_
+#define POLKA__INPUT__IMU_BUFFER_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/imu.hpp>
 #include <Eigen/Core>
 
 #include <deque>
@@ -24,22 +22,29 @@
 #include <mutex>
 #include <string>
 
-namespace polka {
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/imu.hpp>
 
-struct ImuSample {
+namespace polka
+{
+
+struct ImuSample
+{
   double wx = 0.0, wy = 0.0, wz = 0.0;   // angular velocity (rad/s)
   double ax = 0.0, ay = 0.0, az = 0.0;    // linear acceleration (m/s²)
   rclcpp::Time stamp{0, 0, RCL_ROS_TIME};
 };
 
-struct AveragedImu {
+struct AveragedImu
+{
   Eigen::Vector3d angular_vel = Eigen::Vector3d::Zero();
   Eigen::Vector3d linear_accel = Eigen::Vector3d::Zero();
   bool valid = false;
   std::string frame_id;
 };
 
-class ImuBuffer {
+class ImuBuffer
+{
 public:
   ImuBuffer(rclcpp::Node * node, const std::string & topic, int buffer_size);
 
@@ -59,4 +64,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__INPUT__IMU_BUFFER_HPP
+#endif  // POLKA__INPUT__IMU_BUFFER_HPP_

--- a/include/polka/input/source_adapter.hpp
+++ b/include/polka/input/source_adapter.hpp
@@ -12,20 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__INPUT__SOURCE_ADAPTER_HPP
-#define POLKA__INPUT__SOURCE_ADAPTER_HPP
+#ifndef POLKA__INPUT__SOURCE_ADAPTER_HPP_
+#define POLKA__INPUT__SOURCE_ADAPTER_HPP_
 
-#include "polka/types.hpp"
-#include "polka/input/imu_buffer.hpp"
-#include "polka/filters/i_filter.hpp"
-
-#include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
-#include <laser_geometry/laser_geometry.hpp>
 #include <tf2_ros/buffer.h>
-
 #include <Eigen/Core>
+
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -33,26 +25,37 @@
 #include <vector>
 #include <atomic>
 
-namespace polka {
+#include "polka/types.hpp"
+#include "polka/input/imu_buffer.hpp"
+#include "polka/filters/i_filter.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <laser_geometry/laser_geometry.hpp>
 
-class SourceAdapter {
+namespace polka
+{
+
+class SourceAdapter
+{
 public:
   using ImuGetter = std::function<std::shared_ptr<const AveragedImu>()>;
 
-  SourceAdapter(rclcpp::Node * node, const SourceConfig & config, bool gpu_filters = false,
-                ImuGetter imu_getter = nullptr, bool deskew_enabled = false,
-                const std::string & timestamp_field_hint = "auto",
-                std::shared_ptr<tf2_ros::Buffer> tf_buffer = nullptr,
-                int imu_buffer_size = 200);
+  SourceAdapter(
+    rclcpp::Node * node, const SourceConfig & config, bool gpu_filters = false,
+    ImuGetter imu_getter = nullptr, bool deskew_enabled = false,
+    const std::string & timestamp_field_hint = "auto",
+    std::shared_ptr<tf2_ros::Buffer> tf_buffer = nullptr,
+    int imu_buffer_size = 200);
 
   CloudT::ConstPtr get_latest() const;
   bool is_stale(double timeout_sec, const rclcpp::Time & now) const;
-  bool received() const { return has_received_.load(); }
+  bool received() const {return has_received_.load();}
   rclcpp::Time last_stamp() const;
-  std::string name() const { return config_.name; }
+  std::string name() const {return config_.name;}
   std::string frame_id() const;
-  uint64_t message_count() const { return message_counter_.load(); }
-  const FilterParams & filter_params() const { return config_.filter_params; }
+  uint64_t message_count() const {return message_counter_.load();}
+  const FilterParams & filter_params() const {return config_.filter_params;}
   void rebuild_filters(const FilterParams & fp);
 
 private:
@@ -67,8 +70,9 @@ private:
   double extract_point_time(const uint8_t * point_data) const;
   // Fill each point's 'time' field with its absolute acquisition time (Unix sec).
   void populate_point_time(CloudT & cloud, const sensor_msgs::msg::PointCloud2 & raw_msg);
-  void deskew_cloud(CloudT & cloud, const sensor_msgs::msg::PointCloud2 & raw_msg,
-                    const AveragedImu & imu);
+  void deskew_cloud(
+    CloudT & cloud, const sensor_msgs::msg::PointCloud2 & raw_msg,
+    const AveragedImu & imu);
 
   rclcpp::Node * node_;
   SourceConfig config_;
@@ -109,4 +113,4 @@ private:
 
 }  // namespace polka
 
-#endif  // POLKA__INPUT__SOURCE_ADAPTER_HPP
+#endif  // POLKA__INPUT__SOURCE_ADAPTER_HPP_

--- a/include/polka/merge_engine/cpu_merge_engine.hpp
+++ b/include/polka/merge_engine/cpu_merge_engine.hpp
@@ -15,14 +15,18 @@
 #ifndef POLKA__MERGE_ENGINE__CPU_MERGE_ENGINE_HPP_
 #define POLKA__MERGE_ENGINE__CPU_MERGE_ENGINE_HPP_
 
+#include <vector>
+
 #include "polka/merge_engine/i_merge_engine.hpp"
 
-namespace polka {
+namespace polka
+{
 
-class CpuMergeEngine : public IMergeEngine {
+class CpuMergeEngine : public IMergeEngine
+{
 public:
   CloudT::Ptr merge(const std::vector<MergeInput> & sources) override;
-  bool is_gpu() const override { return false; }
+  bool is_gpu() const override {return false;}
 };
 
 }  // namespace polka

--- a/include/polka/merge_engine/cuda_merge_engine.hpp
+++ b/include/polka/merge_engine/cuda_merge_engine.hpp
@@ -12,22 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP
-#define POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP
+#ifndef POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP_
+#define POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP_
 
 #ifdef POLKA_CUDA_ENABLED
 
+#include <vector>
+
 #include "polka/merge_engine/i_merge_engine.hpp"
 
-namespace polka {
+namespace polka
+{
 
-class CudaMergeEngine : public IMergeEngine {
+class CudaMergeEngine : public IMergeEngine
+{
 public:
   explicit CudaMergeEngine(const MergeConfig & config);
   ~CudaMergeEngine() override;
 
   CloudT::Ptr merge(const std::vector<MergeInput> & sources) override;
-  bool is_gpu() const override { return true; }
+  bool is_gpu() const override {return true;}
 
   PipelineResult merge_pipeline(
     const std::vector<MergeInput> & sources,
@@ -41,4 +45,4 @@ private:
 }  // namespace polka
 
 #endif  // POLKA_CUDA_ENABLED
-#endif  // POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP
+#endif  // POLKA__MERGE_ENGINE__CUDA_MERGE_ENGINE_HPP_

--- a/include/polka/merge_engine/i_merge_engine.hpp
+++ b/include/polka/merge_engine/i_merge_engine.hpp
@@ -12,23 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP
-#define POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP
+#ifndef POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP_
+#define POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP_
 
-#include "polka/types.hpp"
-#include <vector>
 #include <Eigen/Geometry>
 
-namespace polka {
+#include <vector>
 
-struct MergeInput {
+#include "polka/types.hpp"
+
+namespace polka
+{
+
+struct MergeInput
+{
   CloudT::ConstPtr cloud;
   Eigen::Isometry3d transform;
   FilterParams filter_params;
 };
 
 // Full GPU pipeline configuration - captures everything needed post-merge
-struct PipelineConfig {
+struct PipelineConfig
+{
   FilterParams output_filters;
   bool self_filter_enabled = false;
   std::vector<ExclusionBox> self_filter_boxes;
@@ -38,12 +43,14 @@ struct PipelineConfig {
   FlattenParams flatten;
 };
 
-struct PipelineResult {
+struct PipelineResult
+{
   CloudT::Ptr cloud;
   std::vector<float> scan_ranges;  // non-empty only when GPU produces scan
 };
 
-class IMergeEngine {
+class IMergeEngine
+{
 public:
   virtual CloudT::Ptr merge(const std::vector<MergeInput> & sources) = 0;
   virtual bool is_gpu() const = 0;
@@ -62,4 +69,4 @@ public:
 
 }  // namespace polka
 
-#endif  // POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP
+#endif  // POLKA__MERGE_ENGINE__I_MERGE_ENGINE_HPP_

--- a/include/polka/output/output_pipeline.hpp
+++ b/include/polka/output/output_pipeline.hpp
@@ -15,19 +15,21 @@
 #ifndef POLKA__OUTPUT__OUTPUT_PIPELINE_HPP_
 #define POLKA__OUTPUT__OUTPUT_PIPELINE_HPP_
 
-#include "polka/types.hpp"
-#include "polka/filters/i_filter.hpp"
-#include "polka/merge_engine/i_merge_engine.hpp"
-
 #include <memory>
 #include <string>
 #include <vector>
 
-namespace polka {
+#include "polka/types.hpp"
+#include "polka/filters/i_filter.hpp"
+#include "polka/merge_engine/i_merge_engine.hpp"
+
+namespace polka
+{
 
 /// CPU post-merge processing pipeline: output filters → height cap → voxel downsample.
 /// Also builds PipelineConfig for the GPU engine path.
-class OutputPipeline {
+class OutputPipeline
+{
 public:
   void configure(const CloudOutputConfig & cfg);
 

--- a/include/polka/output/scan_builder.hpp
+++ b/include/polka/output/scan_builder.hpp
@@ -15,22 +15,24 @@
 #ifndef POLKA__OUTPUT__SCAN_BUILDER_HPP_
 #define POLKA__OUTPUT__SCAN_BUILDER_HPP_
 
-#include "polka/types.hpp"
-
-#include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
-
 #include <string>
 #include <vector>
 
-namespace polka {
+#include "polka/types.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+
+namespace polka
+{
 
 /// Builds sensor_msgs::LaserScan from a merged PointCloud2 or a pre-computed range vector.
 /// Centralises header assembly so both CPU and GPU paths share the same stamp/frame logic.
-class ScanBuilder {
+class ScanBuilder
+{
 public:
-  void configure(const ScanOutputConfig & cfg, double output_rate,
-                 const std::string & frame_id);
+  void configure(
+    const ScanOutputConfig & cfg, double output_rate,
+    const std::string & frame_id);
 
   /// Project a 3D cloud to a 2D LaserScan using the configured flatten parameters.
   sensor_msgs::msg::LaserScan from_cloud(

--- a/include/polka/polka_node.hpp
+++ b/include/polka/polka_node.hpp
@@ -15,17 +15,6 @@
 #ifndef POLKA__POLKA_NODE_HPP_
 #define POLKA__POLKA_NODE_HPP_
 
-#include "polka/types.hpp"
-#include "polka/config/config_loader.hpp"
-#include "polka/input/source_adapter.hpp"
-#include "polka/input/imu_buffer.hpp"
-#include "polka/merge_engine/i_merge_engine.hpp"
-#include "polka/output/output_pipeline.hpp"
-#include "polka/output/scan_builder.hpp"
-
-#include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/point_cloud2.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <Eigen/Geometry>
@@ -35,9 +24,22 @@
 #include <string>
 #include <vector>
 
-namespace polka {
+#include "polka/types.hpp"
+#include "polka/config/config_loader.hpp"
+#include "polka/input/source_adapter.hpp"
+#include "polka/input/imu_buffer.hpp"
+#include "polka/merge_engine/i_merge_engine.hpp"
+#include "polka/output/output_pipeline.hpp"
+#include "polka/output/scan_builder.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
-class PolkaNode : public rclcpp::Node {
+namespace polka
+{
+
+class PolkaNode : public rclcpp::Node
+{
 public:
   explicit PolkaNode(const rclcpp::NodeOptions & options);
 

--- a/include/polka/types.hpp
+++ b/include/polka/types.hpp
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef POLKA__TYPES_HPP
-#define POLKA__TYPES_HPP
+#ifndef POLKA__TYPES_HPP_
+#define POLKA__TYPES_HPP_
+
+#include <pcl/point_types.h>
+#include <pcl/point_cloud.h>
+#include <Eigen/Core>
 
 #include <string>
 #include <vector>
@@ -21,11 +25,8 @@
 #include <stdexcept>
 #include <utility>
 
-#include <pcl/point_types.h>
-#include <pcl/point_cloud.h>
-#include <Eigen/Core>
-
-namespace polka {
+namespace polka
+{
 
 // Point with a per-point acquisition timestamp.
 //
@@ -38,7 +39,8 @@ namespace polka {
 // At publish time, with point_timestamps.mode = OFFSET, PolkaNode::rebase_point_time
 // converts 'time' to an offset relative to the merged cloud header (the convention
 // deskewing consumers expect); with mode = ABSOLUTE it is emitted unchanged.
-struct EIGEN_ALIGN16 PointXYZIT {
+struct EIGEN_ALIGN16 PointXYZIT
+{
   PCL_ADD_POINT4D;       // adds float x, y, z (+ padding) as a SSE-aligned block
   float intensity;
   double time;
@@ -56,12 +58,14 @@ enum class TimestampStrategy { EARLIEST, LATEST, AVERAGE, LOCAL };
 //   ABSOLUTE - raw Unix seconds, as received from the source LiDAR
 enum class PerPointTimeMode { OFFSET, ABSOLUTE };
 
-struct PerPointTimeConfig {
+struct PerPointTimeConfig
+{
   bool enabled = false;                          // emit a per-point 'time' field
   PerPointTimeMode mode = PerPointTimeMode::OFFSET;
 };
 
-struct FilterParams {
+struct FilterParams
+{
   double min_range = 0.0;
   double max_range = 100.0;
   double min_range_sq = 0.0;
@@ -78,30 +82,39 @@ struct FilterParams {
   Eigen::Vector3d box_min = Eigen::Vector3d(-100.0, -100.0, -100.0);
   Eigen::Vector3d box_max = Eigen::Vector3d(100.0, 100.0, 100.0);
 
-  void compute_squared_ranges() {
+  void compute_squared_ranges()
+  {
     min_range_sq = min_range * min_range;
     max_range_sq = max_range * max_range;
   }
 
-  void validate() const {
-    if (min_range < 0)
+  void validate() const
+  {
+    if (min_range < 0) {
       throw std::invalid_argument("min_range must be non-negative");
-    if (max_range <= min_range)
+    }
+    if (max_range <= min_range) {
       throw std::invalid_argument("max_range must be greater than min_range");
+    }
     for (const auto & r : angular_ranges) {
       if (r.first < 0.0 || r.first > 360.0 ||
-          r.second < 0.0 || r.second > 360.0)
+        r.second < 0.0 || r.second > 360.0)
+      {
         throw std::invalid_argument("angular range values must be in [0, 360] degrees");
+      }
     }
     if (box_filter_enabled) {
       if (box_min.x() >= box_max.x() || box_min.y() >= box_max.y() ||
-          box_min.z() >= box_max.z())
+        box_min.z() >= box_max.z())
+      {
         throw std::invalid_argument("box_min must be less than box_max in all dimensions");
+      }
     }
   }
 };
 
-struct FlattenParams {
+struct FlattenParams
+{
   double z_min = -0.15;
   double z_max = 0.15;
   double angle_min = -3.14159265;
@@ -111,23 +124,30 @@ struct FlattenParams {
   double range_max = 100.0;
   int n_bins = 0;
 
-  void compute_bins() {
+  void compute_bins()
+  {
     n_bins = static_cast<int>((angle_max - angle_min) / angle_increment);
   }
 
-  void validate() const {
-    if (z_min >= z_max)
+  void validate() const
+  {
+    if (z_min >= z_max) {
       throw std::invalid_argument("z_min must be less than z_max");
-    if (angle_min >= angle_max)
+    }
+    if (angle_min >= angle_max) {
       throw std::invalid_argument("angle_min must be less than angle_max");
-    if (angle_increment <= 0)
+    }
+    if (angle_increment <= 0) {
       throw std::invalid_argument("angle_increment must be positive");
-    if (range_min < 0 || range_max <= range_min)
+    }
+    if (range_min < 0 || range_max <= range_min) {
       throw std::invalid_argument("range_min must be non-negative and less than range_max");
+    }
   }
 };
 
-struct SourceConfig {
+struct SourceConfig
+{
   std::string name;
   std::string topic;
   std::string imu_topic;  // per-source IMU override (empty = use global)
@@ -137,31 +157,36 @@ struct SourceConfig {
   FilterParams filter_params;
 };
 
-struct HeightCapConfig {
+struct HeightCapConfig
+{
   bool enabled = false;
   double z_min = -1.0;
   double z_max = 3.0;
 };
 
-struct VoxelConfig {
+struct VoxelConfig
+{
   bool enabled = false;
   float leaf_x = 0.0f;
   float leaf_y = 0.0f;
   float leaf_z = 0.0f;
 };
 
-struct ExclusionBox {
+struct ExclusionBox
+{
   Eigen::Vector3d min = Eigen::Vector3d::Zero();
   Eigen::Vector3d max = Eigen::Vector3d::Zero();
   std::string label;
 };
 
-struct SelfFilterConfig {
+struct SelfFilterConfig
+{
   bool enabled = false;
   std::vector<ExclusionBox> boxes;
 };
 
-struct OutputQosConfig {
+struct OutputQosConfig
+{
   std::string reliability = "reliable";
   std::string durability = "volatile";
   int history_depth = 10;
@@ -171,7 +196,8 @@ struct OutputQosConfig {
   double lifespan_ms = 0.0;
 };
 
-struct CloudOutputConfig {
+struct CloudOutputConfig
+{
   bool enabled = true;
   std::string topic = "~/merged_cloud";
   OutputQosConfig qos;
@@ -181,14 +207,16 @@ struct CloudOutputConfig {
   SelfFilterConfig self_filter;
 };
 
-struct ScanOutputConfig {
+struct ScanOutputConfig
+{
   bool enabled = false;
   std::string topic = "~/merged_scan";
   OutputQosConfig qos;
   FlattenParams flatten;
 };
 
-struct MotionCompensationConfig {
+struct MotionCompensationConfig
+{
   bool enabled = false;
   std::string imu_topic = "";                    // sensor_msgs/Imu topic
   double max_imu_age = 0.2;                      // reject stale IMU data (seconds)
@@ -198,7 +226,8 @@ struct MotionCompensationConfig {
   std::string imu_frame = "";                     // empty = auto-detect from IMU msg header
 };
 
-struct MergeConfig {
+struct MergeConfig
+{
   std::string output_frame_id = "base_link";
   double output_rate = 20.0;
   double source_timeout = 0.5;
@@ -224,10 +253,6 @@ struct MergeConfig {
 
 POINT_CLOUD_REGISTER_POINT_STRUCT(
   polka::PointXYZIT,
-  (float, x, x)
-  (float, y, y)
-  (float, z, z)
-  (float, intensity, intensity)
-  (double, time, time))
+  (float, x, x)(float, y, y)(float, z, z)(float, intensity, intensity)(double, time, time))
 
-#endif  // POLKA__TYPES_HPP
+#endif  // POLKA__TYPES_HPP_

--- a/include/polka/util/log_format.hpp
+++ b/include/polka/util/log_format.hpp
@@ -8,14 +8,15 @@
 
 #pragma once
 
-namespace polka {
+namespace polka
+{
 
 // Standard throttle windows (milliseconds) for RCLCPP_*_THROTTLE.
 //   fast   — per-message validation (e.g. non-finite IMU values)
 //   normal — steady-state degradation (e.g. stale source, TF failing)
 //   slow   — persistent suppressed state
-constexpr int kLogThrottleFastMs   = 1000;
+constexpr int kLogThrottleFastMs = 1000;
 constexpr int kLogThrottleNormalMs = 5000;
-constexpr int kLogThrottleSlowMs   = 30000;
+constexpr int kLogThrottleSlowMs = 30000;
 
 }  // namespace polka

--- a/include/polka/util/qos_builder.hpp
+++ b/include/polka/util/qos_builder.hpp
@@ -15,43 +15,50 @@
 #ifndef POLKA__UTIL__QOS_BUILDER_HPP_
 #define POLKA__UTIL__QOS_BUILDER_HPP_
 
-#include "polka/types.hpp"
-
-#include <rclcpp/rclcpp.hpp>
 #include <chrono>
 
-namespace polka {
+#include "polka/types.hpp"
+#include <rclcpp/rclcpp.hpp>
+
+namespace polka
+{
 
 inline rclcpp::QoS build_qos(const OutputQosConfig & cfg)
 {
   rclcpp::QoS qos(cfg.history_depth);
 
-  if (cfg.reliability == "best_effort")
+  if (cfg.reliability == "best_effort") {
     qos.reliability(rclcpp::ReliabilityPolicy::BestEffort);
-  else
+  } else {
     qos.reliability(rclcpp::ReliabilityPolicy::Reliable);
+  }
 
-  if (cfg.durability == "transient_local")
+  if (cfg.durability == "transient_local") {
     qos.durability(rclcpp::DurabilityPolicy::TransientLocal);
-  else
+  } else {
     qos.durability(rclcpp::DurabilityPolicy::Volatile);
+  }
 
-  if (cfg.liveliness == "manual_by_topic")
+  if (cfg.liveliness == "manual_by_topic") {
     qos.liveliness(rclcpp::LivelinessPolicy::ManualByTopic);
-  else
+  } else {
     qos.liveliness(rclcpp::LivelinessPolicy::Automatic);
+  }
 
-  if (cfg.liveliness_lease_duration_ms > 0.0)
+  if (cfg.liveliness_lease_duration_ms > 0.0) {
     qos.liveliness_lease_duration(
       std::chrono::milliseconds(static_cast<int64_t>(cfg.liveliness_lease_duration_ms)));
+  }
 
-  if (cfg.deadline_ms > 0.0)
+  if (cfg.deadline_ms > 0.0) {
     qos.deadline(
       std::chrono::milliseconds(static_cast<int64_t>(cfg.deadline_ms)));
+  }
 
-  if (cfg.lifespan_ms > 0.0)
+  if (cfg.lifespan_ms > 0.0) {
     qos.lifespan(
       std::chrono::milliseconds(static_cast<int64_t>(cfg.lifespan_ms)));
+  }
 
   return qos;
 }

--- a/include/polka/util/se3_exp.hpp
+++ b/include/polka/util/se3_exp.hpp
@@ -24,15 +24,16 @@
 #include <Eigen/Geometry>
 #include <cmath>
 
-namespace polka {
+namespace polka
+{
 
 /// Skew-symmetric matrix [v]_x such that [v]_x * w = v x w.
 inline Eigen::Matrix3d hat(const Eigen::Vector3d & v)
 {
   Eigen::Matrix3d m;
-  m <<     0, -v.z(),  v.y(),
-       v.z(),      0, -v.x(),
-      -v.y(),  v.x(),      0;
+  m << 0, -v.z(), v.y(),
+    v.z(), 0, -v.x(),
+    -v.y(), v.x(), 0;
   return m;
 }
 
@@ -44,8 +45,9 @@ inline Eigen::Matrix3d so3_left_jacobian(const Eigen::Vector3d & phi)
   double theta = phi.norm();
   Eigen::Matrix3d Phi = hat(phi);
 
-  if (theta < 1e-10)
+  if (theta < 1e-10) {
     return Eigen::Matrix3d::Identity() + 0.5 * Phi;
+  }
 
   double theta2 = theta * theta;
   double a = (1.0 - std::cos(theta)) / theta2;
@@ -58,8 +60,9 @@ inline Eigen::Matrix3d so3_left_jacobian(const Eigen::Vector3d & phi)
 ///   ρ: translational component
 ///   φ: rotational component (axis-angle, ‖φ‖ = rotation angle)
 /// Returns T such that T.translation() = V * ρ and T.rotation() = exp(φ).
-inline Eigen::Isometry3d se3_exp(const Eigen::Vector3d & rho,
-                                 const Eigen::Vector3d & phi)
+inline Eigen::Isometry3d se3_exp(
+  const Eigen::Vector3d & rho,
+  const Eigen::Vector3d & phi)
 {
   Eigen::Isometry3d T = Eigen::Isometry3d::Identity();
   double theta = phi.norm();

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -16,7 +16,8 @@
 #include <stdexcept>
 #include <cmath>
 
-namespace polka {
+namespace polka
+{
 
 ConfigLoader::ConfigLoader(rclcpp::Node * node)
 : node_(node), logger_(node->get_logger())
@@ -62,7 +63,9 @@ void ConfigLoader::declare_defaults()
   node_->declare_parameter<double>("outputs.cloud.filters.range.max", 30.0);
   node_->declare_parameter<bool>("outputs.cloud.filters.angular.enabled", false);
   node_->declare_parameter<bool>("outputs.cloud.filters.angular.invert", false);
-  node_->declare_parameter<std::vector<double>>("outputs.cloud.filters.angular.ranges", {0.0, 360.0});
+  node_->declare_parameter<std::vector<double>>(
+    "outputs.cloud.filters.angular.ranges",
+    {0.0, 360.0});
   node_->declare_parameter<bool>("outputs.cloud.filters.box.enabled", false);
   node_->declare_parameter<double>("outputs.cloud.filters.box.x_min", -20.0);
   node_->declare_parameter<double>("outputs.cloud.filters.box.x_max", 20.0);
@@ -137,8 +140,8 @@ FilterParams ConfigLoader::load_filter_params(const std::string & prefix)
   for (size_t i = 0; i + 1 < ang_flat.size(); i += 2) {
     double lo = std::fmod(ang_flat[i], 360.0);
     double hi = std::fmod(ang_flat[i + 1], 360.0);
-    if (lo < 0.0) lo += 360.0;
-    if (hi < 0.0) hi += 360.0;
+    if (lo < 0.0) {lo += 360.0;}
+    if (hi < 0.0) {hi += 360.0;}
     fp.angular_ranges.emplace_back(lo, hi);
   }
 
@@ -166,17 +169,23 @@ MergeConfig ConfigLoader::read_common_params()
   cfg.max_source_spread_warn = node_->get_parameter("max_source_spread_warn").as_double();
 
   auto ts_str = node_->get_parameter("timestamp_strategy").as_string();
-  if (ts_str == "earliest") cfg.timestamp_strategy = TimestampStrategy::EARLIEST;
-  else if (ts_str == "latest") cfg.timestamp_strategy = TimestampStrategy::LATEST;
-  else if (ts_str == "average") cfg.timestamp_strategy = TimestampStrategy::AVERAGE;
-  else if (ts_str == "local") cfg.timestamp_strategy = TimestampStrategy::LOCAL;
-  else throw std::runtime_error("polka: invalid timestamp_strategy '" + ts_str + "'");
+  if (ts_str == "earliest") {
+    cfg.timestamp_strategy = TimestampStrategy::EARLIEST;
+  } else if (ts_str == "latest") {
+    cfg.timestamp_strategy = TimestampStrategy::LATEST;
+  } else if (ts_str == "average") {
+    cfg.timestamp_strategy = TimestampStrategy::AVERAGE;
+  } else if (ts_str == "local") {cfg.timestamp_strategy = TimestampStrategy::LOCAL;} else {
+    throw std::runtime_error("polka: invalid timestamp_strategy '" + ts_str + "'");
+  }
 
   cfg.point_timestamps.enabled = node_->get_parameter("point_timestamps.enabled").as_bool();
   auto ppt_mode = node_->get_parameter("point_timestamps.mode").as_string();
-  if (ppt_mode == "offset") cfg.point_timestamps.mode = PerPointTimeMode::OFFSET;
-  else if (ppt_mode == "absolute") cfg.point_timestamps.mode = PerPointTimeMode::ABSOLUTE;
-  else throw std::runtime_error("polka: invalid point_timestamps.mode '" + ppt_mode + "'");
+  if (ppt_mode == "offset") {
+    cfg.point_timestamps.mode = PerPointTimeMode::OFFSET;
+  } else if (ppt_mode == "absolute") {
+    cfg.point_timestamps.mode = PerPointTimeMode::ABSOLUTE;
+  } else {throw std::runtime_error("polka: invalid point_timestamps.mode '" + ppt_mode + "'");}
   cfg.suppress_duplicate_timestamps =
     node_->get_parameter("suppress_duplicate_timestamps").as_bool();
 
@@ -205,8 +214,9 @@ MergeConfig ConfigLoader::read_common_params()
     double lx = node_->get_parameter("outputs.cloud.voxel.leaf_x").as_double();
     double ly = node_->get_parameter("outputs.cloud.voxel.leaf_y").as_double();
     double lz = node_->get_parameter("outputs.cloud.voxel.leaf_z").as_double();
-    if (uniform > 0.0 && lx == 0.0 && ly == 0.0 && lz == 0.0)
+    if (uniform > 0.0 && lx == 0.0 && ly == 0.0 && lz == 0.0) {
       lx = ly = lz = uniform;
+    }
     cfg.cloud_output.voxel.leaf_x = static_cast<float>(lx);
     cfg.cloud_output.voxel.leaf_y = static_cast<float>(ly);
     cfg.cloud_output.voxel.leaf_z = static_cast<float>(lz);
@@ -229,7 +239,8 @@ MergeConfig ConfigLoader::read_common_params()
   cfg.scan_output.flatten.z_max = node_->get_parameter("outputs.scan.z_max").as_double();
   cfg.scan_output.flatten.angle_min = node_->get_parameter("outputs.scan.angle_min").as_double();
   cfg.scan_output.flatten.angle_max = node_->get_parameter("outputs.scan.angle_max").as_double();
-  cfg.scan_output.flatten.angle_increment = node_->get_parameter("outputs.scan.angle_increment").as_double();
+  cfg.scan_output.flatten.angle_increment =
+    node_->get_parameter("outputs.scan.angle_increment").as_double();
   cfg.scan_output.flatten.range_min = node_->get_parameter("outputs.scan.range_min").as_double();
   cfg.scan_output.flatten.range_max = node_->get_parameter("outputs.scan.range_max").as_double();
   cfg.scan_output.flatten.compute_bins();
@@ -328,7 +339,7 @@ SelfFilterConfig ConfigLoader::load_self_filter_config(const std::string & prefi
 {
   SelfFilterConfig sf;
   sf.enabled = node_->get_parameter(prefix + ".enabled").as_bool();
-  if (!sf.enabled) return sf;
+  if (!sf.enabled) {return sf;}
 
   auto box_names = node_->get_parameter(prefix + ".box_names").as_string_array();
   for (const auto & name : box_names) {
@@ -355,24 +366,31 @@ SelfFilterConfig ConfigLoader::load_self_filter_config(const std::string & prefi
 
 void ConfigLoader::validate(const MergeConfig & config)
 {
-  if (config.sources.empty())
+  if (config.sources.empty()) {
     throw std::runtime_error("polka: source_names is empty");
-  if (config.output_rate <= 0.0 && config.output_rate != -1.0)
+  }
+  if (config.output_rate <= 0.0 && config.output_rate != -1.0) {
     throw std::runtime_error("polka: output_rate must be > 0 or -1 (adaptive)");
-  if (config.source_timeout <= 0.0)
+  }
+  if (config.source_timeout <= 0.0) {
     throw std::runtime_error("polka: source_timeout must be > 0");
-  if (!config.cloud_output.enabled && !config.scan_output.enabled)
+  }
+  if (!config.cloud_output.enabled && !config.scan_output.enabled) {
     throw std::runtime_error("polka: at least one output (cloud or scan) must be enabled");
+  }
   if (config.cloud_output.voxel.enabled) {
     if (config.cloud_output.voxel.leaf_x <= 0.0f ||
-        config.cloud_output.voxel.leaf_y <= 0.0f ||
-        config.cloud_output.voxel.leaf_z <= 0.0f)
+      config.cloud_output.voxel.leaf_y <= 0.0f ||
+      config.cloud_output.voxel.leaf_z <= 0.0f)
+    {
       throw std::runtime_error(
-        "polka: voxel filter enabled but leaf size is <= 0 (would crash pcl::VoxelGrid)");
+              "polka: voxel filter enabled but leaf size is <= 0 (would crash pcl::VoxelGrid)");
+    }
   }
   for (const auto & src : config.sources) {
-    if (src.topic.empty())
+    if (src.topic.empty()) {
       throw std::runtime_error("polka: source '" + src.name + "' has empty topic");
+    }
   }
 }
 

--- a/src/filters/angular_filter.cpp
+++ b/src/filters/angular_filter.cpp
@@ -15,7 +15,8 @@
 #include "polka/filters/angular_filter.hpp"
 #include <cmath>
 
-namespace polka {
+namespace polka
+{
 
 AngularFilter::AngularFilter(
   const std::vector<std::pair<double, double>> & ranges_deg, bool invert)
@@ -27,9 +28,9 @@ bool AngularFilter::in_ranges(double angle_deg) const
 {
   for (const auto & r : ranges_deg_) {
     if (r.first <= r.second) {
-      if (angle_deg >= r.first && angle_deg <= r.second) return true;
+      if (angle_deg >= r.first && angle_deg <= r.second) {return true;}
     } else {
-      if (angle_deg >= r.first || angle_deg <= r.second) return true;
+      if (angle_deg >= r.first || angle_deg <= r.second) {return true;}
     }
   }
   return false;
@@ -42,7 +43,7 @@ void AngularFilter::apply(CloudT & cloud, const std::string & /*frame_id*/)
     const auto & p = cloud[i];
     double angle_rad = std::atan2(static_cast<double>(p.y), static_cast<double>(p.x));
     double angle_deg = angle_rad * 180.0 / M_PI;
-    if (angle_deg < 0.0) angle_deg += 360.0;
+    if (angle_deg < 0.0) {angle_deg += 360.0;}
 
     bool match = in_ranges(angle_deg);
     bool keep = invert_ ? !match : match;

--- a/src/filters/box_filter.cpp
+++ b/src/filters/box_filter.cpp
@@ -14,10 +14,12 @@
 
 #include "polka/filters/box_filter.hpp"
 
-namespace polka {
+namespace polka
+{
 
-BoxFilter::BoxFilter(const Eigen::Vector3d & box_min, const Eigen::Vector3d & box_max,
-                     bool invert)
+BoxFilter::BoxFilter(
+  const Eigen::Vector3d & box_min, const Eigen::Vector3d & box_max,
+  bool invert)
 : bx_min_(static_cast<float>(box_min.x())), bx_max_(static_cast<float>(box_max.x())),
   by_min_(static_cast<float>(box_min.y())), by_max_(static_cast<float>(box_max.y())),
   bz_min_(static_cast<float>(box_min.z())), bz_max_(static_cast<float>(box_max.z())),
@@ -31,8 +33,8 @@ void BoxFilter::apply(CloudT & cloud, const std::string & /*frame_id*/)
   for (size_t i = 0; i < cloud.size(); ++i) {
     const auto & p = cloud[i];
     bool inside = p.x >= bx_min_ && p.x <= bx_max_ &&
-                  p.y >= by_min_ && p.y <= by_max_ &&
-                  p.z >= bz_min_ && p.z <= bz_max_;
+      p.y >= by_min_ && p.y <= by_max_ &&
+      p.z >= bz_min_ && p.z <= bz_max_;
     if (inside != invert_) {
       cloud[j++] = p;
     }

--- a/src/filters/range_filter.cpp
+++ b/src/filters/range_filter.cpp
@@ -14,7 +14,8 @@
 
 #include "polka/filters/range_filter.hpp"
 
-namespace polka {
+namespace polka
+{
 
 RangeFilter::RangeFilter(double min_range, double max_range)
 : min_range_sq_(static_cast<float>(min_range * min_range)),

--- a/src/imu_buffer.cpp
+++ b/src/imu_buffer.cpp
@@ -13,11 +13,15 @@
 // limitations under the License.
 
 #include "polka/input/imu_buffer.hpp"
-#include "polka/util/log_format.hpp"
+
 #include <Eigen/Geometry>
+
 #include <cmath>
 
-namespace polka {
+#include "polka/util/log_format.hpp"
+
+namespace polka
+{
 
 ImuBuffer::ImuBuffer(rclcpp::Node * node, const std::string & topic, int buffer_size)
 : max_size_(buffer_size), logger_(node->get_logger()), clock_(node->get_clock())
@@ -25,7 +29,8 @@ ImuBuffer::ImuBuffer(rclcpp::Node * node, const std::string & topic, int buffer_
   sub_ = node->create_subscription<sensor_msgs::msg::Imu>(
     topic, rclcpp::SensorDataQoS(),
     std::bind(&ImuBuffer::callback, this, std::placeholders::_1));
-  RCLCPP_INFO(logger_, "polka: IMU buffer subscribing to '%s' (capacity %d)",
+  RCLCPP_INFO(
+    logger_, "polka: IMU buffer subscribing to '%s' (capacity %d)",
     topic.c_str(), buffer_size);
 }
 
@@ -39,8 +44,10 @@ void ImuBuffer::callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
   const auto & a = msg->linear_acceleration;
   const auto & w = msg->angular_velocity;
   if (!std::isfinite(a.x) || !std::isfinite(a.y) || !std::isfinite(a.z) ||
-      !std::isfinite(w.x) || !std::isfinite(w.y) || !std::isfinite(w.z)) {
-    RCLCPP_WARN_THROTTLE(logger_, *clock_, kLogThrottleFastMs,
+    !std::isfinite(w.x) || !std::isfinite(w.y) || !std::isfinite(w.z))
+  {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, kLogThrottleFastMs,
       "polka: IMU buffer received non-finite values, ignoring");
     return;
   }
@@ -57,12 +64,14 @@ void ImuBuffer::callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
       accel -= g_imu;
     } else {
       accel.setZero();
-      RCLCPP_WARN_THROTTLE(logger_, *clock_, kLogThrottleNormalMs,
+      RCLCPP_WARN_THROTTLE(
+        logger_, *clock_, kLogThrottleNormalMs,
         "polka: IMU has degenerate orientation quaternion, translation deskew disabled");
     }
   } else {
     accel.setZero();
-    RCLCPP_WARN_ONCE(logger_,
+    RCLCPP_WARN_ONCE(
+      logger_,
       "polka: IMU has no orientation — cannot subtract gravity, "
       "translation deskew disabled (rotation-only)");
   }
@@ -75,8 +84,9 @@ void ImuBuffer::callback(sensor_msgs::msg::Imu::ConstSharedPtr msg)
   {
     std::lock_guard<std::mutex> lock(mutex_);
     buffer_.push_back(sample);
-    while (static_cast<int>(buffer_.size()) > max_size_)
+    while (static_cast<int>(buffer_.size()) > max_size_) {
       buffer_.pop_front();
+    }
   }
 
   auto avg = std::make_shared<AveragedImu>();

--- a/src/merge_engine/cpu_merge_engine.cpp
+++ b/src/merge_engine/cpu_merge_engine.cpp
@@ -15,14 +15,16 @@
 #include "polka/merge_engine/cpu_merge_engine.hpp"
 #include <cmath>
 
-namespace polka {
+namespace polka
+{
 
 CloudT::Ptr CpuMergeEngine::merge(const std::vector<MergeInput> & sources)
 {
   auto output = std::make_shared<CloudT>();
   size_t total = 0;
-  for (const auto & src : sources)
+  for (const auto & src : sources) {
     total += src.cloud->size();
+  }
   output->resize(total);
 
   size_t out_idx = 0;
@@ -30,8 +32,9 @@ CloudT::Ptr CpuMergeEngine::merge(const std::vector<MergeInput> & sources)
     Eigen::Affine3f tf = src.transform.cast<float>();
     for (size_t i = 0; i < src.cloud->size(); ++i) {
       const auto & p = (*src.cloud)[i];
-      if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z))
+      if (!std::isfinite(p.x) || !std::isfinite(p.y) || !std::isfinite(p.z)) {
         continue;
+      }
       auto & o = (*output)[out_idx++];
       Eigen::Vector3f out = tf * Eigen::Vector3f(p.x, p.y, p.z);
       o.x = out.x();

--- a/src/output/output_pipeline.cpp
+++ b/src/output/output_pipeline.cpp
@@ -13,16 +13,18 @@
 // limitations under the License.
 
 #include "polka/output/output_pipeline.hpp"
-#include "polka/filters/filter_chain.hpp"
-#include "polka/filters/box_filter.hpp"
 
 #include <pcl/filters/voxel_grid.h>
+
+#include "polka/filters/filter_chain.hpp"
+#include "polka/filters/box_filter.hpp"
 // PointXYZIT is a custom point type, so VoxelGrid/PCLBase are not pre-instantiated
 // in libpcl; pull in the template implementations to instantiate them here.
 #include <pcl/impl/pcl_base.hpp>
 #include <pcl/filters/impl/voxel_grid.hpp>
 
-namespace polka {
+namespace polka
+{
 
 void OutputPipeline::configure(const CloudOutputConfig & cfg)
 {
@@ -39,23 +41,26 @@ void OutputPipeline::build_filters()
 {
   filters_ = build_filter_chain(config_.filters);
   if (config_.self_filter.enabled) {
-    for (const auto & eb : config_.self_filter.boxes)
+    for (const auto & eb : config_.self_filter.boxes) {
       filters_.push_back(std::make_unique<BoxFilter>(eb.min, eb.max, true));
+    }
   }
 }
 
 void OutputPipeline::process(CloudT & cloud, const std::string & frame_id) const
 {
-  for (const auto & filter : filters_)
+  for (const auto & filter : filters_) {
     filter->apply(cloud, frame_id);
+  }
 
   if (config_.height_cap.enabled) {
     const float z_min = static_cast<float>(config_.height_cap.z_min);
     const float z_max = static_cast<float>(config_.height_cap.z_max);
     size_t j = 0;
     for (size_t i = 0; i < cloud.size(); ++i) {
-      if (cloud[i].z >= z_min && cloud[i].z <= z_max)
+      if (cloud[i].z >= z_min && cloud[i].z <= z_max) {
         cloud[j++] = cloud[i];
+      }
     }
     cloud.resize(j);
     cloud.width = static_cast<uint32_t>(j);
@@ -83,8 +88,9 @@ PipelineConfig OutputPipeline::to_pipeline_config(
   pcfg.height_cap = config_.height_cap;
   pcfg.voxel = config_.voxel;
   pcfg.scan_enabled = scan_enabled;
-  if (scan_enabled)
+  if (scan_enabled) {
     pcfg.flatten = flatten;
+  }
   return pcfg;
 }
 

--- a/src/output/scan_builder.cpp
+++ b/src/output/scan_builder.cpp
@@ -17,7 +17,8 @@
 #include <cmath>
 #include <limits>
 
-namespace polka {
+namespace polka
+{
 
 void ScanBuilder::configure(
   const ScanOutputConfig & cfg, double output_rate, const std::string & frame_id)
@@ -60,13 +61,13 @@ sensor_msgs::msg::LaserScan ScanBuilder::from_cloud(
   scan.ranges.assign(n, std::numeric_limits<float>::infinity());
 
   for (const auto & p : *cloud) {
-    if (p.z < z_min || p.z > z_max) continue;
+    if (p.z < z_min || p.z > z_max) {continue;}
     float az = std::atan2(p.y, p.x);
-    if (az < a_min || az > a_max) continue;
+    if (az < a_min || az > a_max) {continue;}
     int bin = static_cast<int>((az - a_min) / a_inc);
-    if (bin < 0 || bin >= n) continue;
+    if (bin < 0 || bin >= n) {continue;}
     float range = std::sqrt(p.x * p.x + p.y * p.y);
-    if (range < r_min || range > r_max) continue;
+    if (range < r_min || range > r_max) {continue;}
     scan.ranges[bin] = std::min(scan.ranges[bin], range);
   }
   return scan;

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -13,16 +13,13 @@
 // limitations under the License.
 
 #include "polka/polka_node.hpp"
-#include "polka/util/log_format.hpp"
-#include "polka/util/qos_builder.hpp"
-#include "polka/util/se3_exp.hpp"
-#include "polka/merge_engine/cpu_merge_engine.hpp"
 
 #include <pcl_conversions/pcl_conversions.h>
 #include <pcl/console/print.h>
 #include <pcl/common/io.h>
-#include <tf2_eigen/tf2_eigen.hpp>
-#include <rcl_interfaces/msg/set_parameters_result.hpp>
+#ifdef POLKA_CUDA_ENABLED
+#include <cuda_runtime.h>
+#endif
 
 #include <algorithm>
 #include <chrono>
@@ -30,12 +27,19 @@
 #include <functional>
 #include <sstream>
 
+#include "polka/util/log_format.hpp"
+#include "polka/util/qos_builder.hpp"
+#include "polka/util/se3_exp.hpp"
+#include "polka/merge_engine/cpu_merge_engine.hpp"
+#include <tf2_eigen/tf2_eigen.hpp>
+#include <rcl_interfaces/msg/set_parameters_result.hpp>
+
 #ifdef POLKA_CUDA_ENABLED
 #include "polka/merge_engine/cuda_merge_engine.hpp"
-#include <cuda_runtime.h>
 #endif
 
-namespace polka {
+namespace polka
+{
 
 PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
 : rclcpp::Node("polka", options), config_loader_(this)
@@ -58,49 +62,58 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
     if (device_count > 0) {
       merge_engine_ = std::make_unique<CudaMergeEngine>(config_);
     } else {
-      RCLCPP_WARN(get_logger(),
+      RCLCPP_WARN(
+        get_logger(),
         "polka: enable_gpu=true but no CUDA device found, falling back to CPU");
     }
   }
 #endif
-  if (!merge_engine_)
+  if (!merge_engine_) {
     merge_engine_ = std::make_unique<CpuMergeEngine>();
+  }
 
-  if (config_.motion_compensation.enabled && !config_.motion_compensation.imu_topic.empty())
+  if (config_.motion_compensation.enabled && !config_.motion_compensation.imu_topic.empty()) {
     global_imu_ = std::make_shared<ImuBuffer>(
       this, config_.motion_compensation.imu_topic,
       config_.motion_compensation.imu_buffer_size);
-  else if (config_.motion_compensation.enabled)
-    RCLCPP_WARN(get_logger(),
+  } else if (config_.motion_compensation.enabled) {
+    RCLCPP_WARN(
+      get_logger(),
       "polka: motion compensation enabled but imu_topic is empty, deskewing will not activate");
+  }
 
   SourceAdapter::ImuGetter imu_getter = nullptr;
-  if (config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew
-      && global_imu_) {
+  if (config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew &&
+    global_imu_)
+  {
     imu_getter = [this]() -> std::shared_ptr<const AveragedImu> {
-      return global_imu_->snapshot();
-    };
+        return global_imu_->snapshot();
+      };
   }
 
   bool gpu_filters = merge_engine_->is_gpu();
   bool deskew = config_.motion_compensation.enabled && config_.motion_compensation.per_point_deskew;
-  for (const auto & src_cfg : config_.sources)
-    sources_.push_back(std::make_unique<SourceAdapter>(
-      this, src_cfg, gpu_filters, imu_getter, deskew,
-      config_.motion_compensation.deskew_timestamp_field,
-      tf_buffer_, config_.motion_compensation.imu_buffer_size));
+  for (const auto & src_cfg : config_.sources) {
+    sources_.push_back(
+      std::make_unique<SourceAdapter>(
+        this, src_cfg, gpu_filters, imu_getter, deskew,
+        config_.motion_compensation.deskew_timestamp_field,
+        tf_buffer_, config_.motion_compensation.imu_buffer_size));
+  }
 
   last_good_transforms_.resize(sources_.size(), Eigen::Isometry3d::Identity());
 
   output_pipeline_.configure(config_.cloud_output);
   scan_builder_.configure(config_.scan_output, config_.output_rate, config_.output_frame_id);
 
-  if (config_.cloud_output.enabled)
+  if (config_.cloud_output.enabled) {
     cloud_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
       config_.cloud_output.topic, build_qos(config_.cloud_output.qos));
-  if (config_.scan_output.enabled)
+  }
+  if (config_.scan_output.enabled) {
     scan_pub_ = create_publisher<sensor_msgs::msg::LaserScan>(
       config_.scan_output.topic, build_qos(config_.scan_output.qos));
+  }
 
   if (config_.output_rate > 0.0) {
     auto period = std::chrono::duration<double>(1.0 / config_.output_rate);
@@ -109,8 +122,9 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
       std::bind(&PolkaNode::output_callback, this));
   }
 
-  for (const auto & sc : config_.sources)
+  for (const auto & sc : config_.sources) {
     source_names_.push_back(sc.name);
+  }
 
   log_startup_banner();
 
@@ -124,18 +138,18 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
 
 void PolkaNode::diagnose_clock_health(const rclcpp::Time & now)
 {
-  if (clock_diagnosed_) return;
+  if (clock_diagnosed_) {return;}
 
   // Newest sensor stamp across sources that have actually received data. Without any
   // data there is nothing to compare the clock against, so we can't judge yet.
   rclcpp::Time newest;
   bool any = false;
   for (const auto & src : sources_) {
-    if (!src->received()) continue;
+    if (!src->received()) {continue;}
     auto stamp = src->last_stamp();
-    if (!any || stamp > newest) { newest = stamp; any = true; }
+    if (!any || stamp > newest) {newest = stamp; any = true;}
   }
-  if (!any) return;
+  if (!any) {return;}
 
   const double dt = (now - newest).seconds();
   const bool sim = this->get_parameter("use_sim_time").as_bool();
@@ -143,18 +157,20 @@ void PolkaNode::diagnose_clock_health(const rclcpp::Time & now)
   // Allow normal jitter (and the correct --clock case): only react when the clock and
   // the data disagree by several staleness windows.
   const double mismatch = std::max(2.0, config_.source_timeout * 4.0);
-  if (std::fabs(dt) < mismatch) return;
+  if (std::fabs(dt) < mismatch) {return;}
 
   if (sim && count_publishers("/clock") == 0) {
     // Sim time requested but nothing drives /clock, so the clock is frozen near zero.
-    RCLCPP_WARN(get_logger(),
+    RCLCPP_WARN(
+      get_logger(),
       "polka: use_sim_time=true but no publisher on /clock was found — the simulated "
       "clock is not advancing, so timestamp/staleness checks are unreliable. If you are "
       "replaying a rosbag, play it with the --clock flag: ros2 bag play <bag> --clock");
     clock_diagnosed_ = true;
   } else if (!sim && dt > mismatch) {
     // Wall clock vs historical bag stamps: every source will be dropped as stale.
-    RCLCPP_WARN(get_logger(),
+    RCLCPP_WARN(
+      get_logger(),
       "polka: sensor timestamps are %.1f s behind the system clock. This looks like "
       "rosbag replay without simulated time; all sources will be dropped as stale and "
       "no merged cloud will be published. Set use_sim_time:=true and replay with the "
@@ -170,7 +186,8 @@ void PolkaNode::output_callback()
   auto now = this->now();
   diagnose_clock_health(now);
 
-  struct SourceData {
+  struct SourceData
+  {
     CloudT::ConstPtr cloud;
     Eigen::Isometry3d transform;
     FilterParams filter_params;
@@ -181,10 +198,11 @@ void PolkaNode::output_callback()
   for (size_t i = 0; i < sources_.size(); ++i) {
     auto & src = sources_[i];
     auto cloud = src->get_latest();
-    if (!cloud || cloud->empty()) continue;
+    if (!cloud || cloud->empty()) {continue;}
 
     if (src->is_stale(config_.source_timeout, now)) {
-      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleNormalMs,
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), kLogThrottleNormalMs,
         "polka: source '%s' is stale", src->name().c_str());
       continue;
     }
@@ -196,7 +214,8 @@ void PolkaNode::output_callback()
       transform = tf2::transformToEigen(tf_msg.transform);
       last_good_transforms_[i] = transform;
     } catch (const tf2::TransformException & ex) {
-      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleNormalMs,
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), kLogThrottleNormalMs,
         "polka: TF failed for '%s': %s — using last known good transform",
         src->name().c_str(), ex.what());
       transform = last_good_transforms_[i];
@@ -210,7 +229,7 @@ void PolkaNode::output_callback()
     // nothing rather than re-publishing the last cloud with its original stamp: a
     // duplicate header.stamp hands downstream SLAM (e.g. GLIM) two scans with zero
     // IMU samples between them and stalls odometry. A genuine gap is safe to skip.
-    if (config_.suppress_duplicate_timestamps) return;
+    if (config_.suppress_duplicate_timestamps) {return;}
     std::lock_guard<std::mutex> lock(last_data_mutex_);
     if (last_cloud_ && !last_cloud_->empty()) {
       if (cloud_pub_) {
@@ -220,9 +239,9 @@ void PolkaNode::output_callback()
         cloud_pub_->publish(msg);
       }
       if (scan_pub_) {
-        auto scan = last_scan_ranges_.empty()
-          ? scan_builder_.from_cloud(last_cloud_, last_cloud_stamp_)
-          : scan_builder_.from_ranges(last_scan_ranges_, last_cloud_stamp_);
+        auto scan = last_scan_ranges_.empty() ?
+          scan_builder_.from_cloud(last_cloud_, last_cloud_stamp_) :
+          scan_builder_.from_ranges(last_scan_ranges_, last_cloud_stamp_);
         scan_pub_->publish(scan);
       }
     }
@@ -231,15 +250,18 @@ void PolkaNode::output_callback()
 
   std::vector<rclcpp::Time> stamps;
   stamps.reserve(source_data.size());
-  for (const auto & sd : source_data)
+  for (const auto & sd : source_data) {
     stamps.push_back(sd.stamp);
+  }
 
   if (stamps.size() > 1) {
     auto [mn, mx] = std::minmax_element(stamps.begin(), stamps.end());
     double spread = (*mx - *mn).seconds();
-    if (spread > config_.max_source_spread_warn)
-      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), kLogThrottleNormalMs,
+    if (spread > config_.max_source_spread_warn) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), kLogThrottleNormalMs,
         "polka: source spread %6.3f s > %6.3f s", spread, config_.max_source_spread_warn);
+    }
   }
 
   auto output_stamp = compute_output_stamp(stamps);
@@ -250,7 +272,7 @@ void PolkaNode::output_callback()
   // header.stamp and no IMU between them. Skip until the stamp actually moves.
   if (config_.suppress_duplicate_timestamps) {
     std::lock_guard<std::mutex> lock(last_data_mutex_);
-    if (last_cloud_ && output_stamp == last_cloud_stamp_) return;
+    if (last_cloud_ && output_stamp == last_cloud_stamp_) {return;}
   }
 
   bool do_compensate = false;
@@ -282,12 +304,14 @@ void PolkaNode::output_callback()
     auto pcfg = output_pipeline_.to_pipeline_config(
       scan_pub_ != nullptr, config_.scan_output.flatten);
     auto result = merge_engine_->merge_pipeline(inputs, pcfg);
-    if (!result.cloud || result.cloud->empty()) return;
+    if (!result.cloud || result.cloud->empty()) {return;}
 
     if (cloud_pub_) {
       if (config_.point_timestamps.enabled &&
-          config_.point_timestamps.mode == PerPointTimeMode::OFFSET)
+        config_.point_timestamps.mode == PerPointTimeMode::OFFSET)
+      {
         rebase_point_time(*result.cloud, output_stamp);
+      }
       auto msg = to_cloud_msg(*result.cloud);
       msg.header.frame_id = config_.output_frame_id;
       msg.header.stamp = output_stamp;
@@ -297,28 +321,32 @@ void PolkaNode::output_callback()
       last_cloud_stamp_ = output_stamp;
     }
     if (scan_pub_) {
-      auto scan = result.scan_ranges.empty()
-        ? scan_builder_.from_cloud(result.cloud, output_stamp)
-        : scan_builder_.from_ranges(result.scan_ranges, output_stamp);
+      auto scan = result.scan_ranges.empty() ?
+        scan_builder_.from_cloud(result.cloud, output_stamp) :
+        scan_builder_.from_ranges(result.scan_ranges, output_stamp);
       scan_pub_->publish(scan);
       std::lock_guard<std::mutex> lock(last_data_mutex_);
       last_scan_ranges_ = result.scan_ranges;
     }
   } else {
     auto merged = merge_engine_->merge(inputs);
-    if (!merged || merged->empty()) return;
+    if (!merged || merged->empty()) {return;}
 
-    if (config_.point_timestamps.enabled && config_.cloud_output.voxel.enabled)
-      RCLCPP_WARN_ONCE(get_logger(),
+    if (config_.point_timestamps.enabled && config_.cloud_output.voxel.enabled) {
+      RCLCPP_WARN_ONCE(
+        get_logger(),
         "polka: CPU voxel downsampling reduces per-point 'time' precision to float; "
         "use enable_gpu for exact per-point time");
+    }
 
     output_pipeline_.process(*merged, config_.output_frame_id);
 
     if (cloud_pub_) {
       if (config_.point_timestamps.enabled &&
-          config_.point_timestamps.mode == PerPointTimeMode::OFFSET)
+        config_.point_timestamps.mode == PerPointTimeMode::OFFSET)
+      {
         rebase_point_time(*merged, output_stamp);
+      }
       auto msg = to_cloud_msg(*merged);
       msg.header.frame_id = config_.output_frame_id;
       msg.header.stamp = output_stamp;
@@ -338,7 +366,7 @@ void PolkaNode::output_callback()
 
 rclcpp::Time PolkaNode::compute_output_stamp(const std::vector<rclcpp::Time> & stamps)
 {
-  if (stamps.empty()) return this->now();
+  if (stamps.empty()) {return this->now();}
   switch (config_.timestamp_strategy) {
     case TimestampStrategy::EARLIEST:
       return *std::min_element(stamps.begin(), stamps.end());
@@ -347,10 +375,12 @@ rclcpp::Time PolkaNode::compute_output_stamp(const std::vector<rclcpp::Time> & s
     case TimestampStrategy::LOCAL:
       return this->now();
     case TimestampStrategy::AVERAGE: {
-      double sum = 0.0;
-      for (const auto & s : stamps) sum += s.seconds();
-      return rclcpp::Time(static_cast<int64_t>((sum / stamps.size()) * 1e9));
-    }
+        double sum = 0.0;
+        for (const auto & s : stamps) {
+          sum += s.seconds();
+        }
+        return rclcpp::Time(static_cast<int64_t>((sum / stamps.size()) * 1e9));
+      }
     default:
       return this->now();
   }
@@ -362,8 +392,9 @@ void PolkaNode::rebase_point_time(CloudT & cloud, const rclcpp::Time & stamp)
   // a per-point offset relative to the cloud header. Subtracting in double keeps
   // ~sub-microsecond precision even though the absolute values are ~1.7e9.
   const double base = stamp.seconds();
-  for (auto & p : cloud)
+  for (auto & p : cloud) {
     p.time -= base;
+  }
 }
 
 sensor_msgs::msg::PointCloud2 PolkaNode::to_cloud_msg(const CloudT & cloud) const
@@ -406,21 +437,23 @@ bool PolkaNode::reconfigure()
     changes.emplace_back(buf);
   }
 
-  if (config_.cloud_output.enabled && !prev_cloud_enabled)
+  if (config_.cloud_output.enabled && !prev_cloud_enabled) {
     cloud_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
       config_.cloud_output.topic, build_qos(config_.cloud_output.qos));
-  else if (!config_.cloud_output.enabled && prev_cloud_enabled)
+  } else if (!config_.cloud_output.enabled && prev_cloud_enabled) {
     cloud_pub_.reset();
+  }
 
-  if (config_.scan_output.enabled && !prev_scan_enabled)
+  if (config_.scan_output.enabled && !prev_scan_enabled) {
     scan_pub_ = create_publisher<sensor_msgs::msg::LaserScan>(
       config_.scan_output.topic, build_qos(config_.scan_output.qos));
-  else if (!config_.scan_output.enabled && prev_scan_enabled)
+  } else if (!config_.scan_output.enabled && prev_scan_enabled) {
     scan_pub_.reset();
+  }
 
   bool imu_was_enabled = (global_imu_ != nullptr);
-  bool imu_now_enabled = config_.motion_compensation.enabled
-                         && !config_.motion_compensation.imu_topic.empty();
+  bool imu_now_enabled = config_.motion_compensation.enabled &&
+    !config_.motion_compensation.imu_topic.empty();
   if (imu_now_enabled && !imu_was_enabled) {
     global_imu_ = std::make_shared<ImuBuffer>(
       this, config_.motion_compensation.imu_topic,
@@ -431,25 +464,28 @@ bool PolkaNode::reconfigure()
     changes.emplace_back("motion_compensation=off");
   }
 
-  if (config_.cloud_output.enabled != prev_cloud_enabled)
+  if (config_.cloud_output.enabled != prev_cloud_enabled) {
     changes.emplace_back(
       std::string("cloud_output=") + (config_.cloud_output.enabled ? "on" : "off"));
-  if (config_.scan_output.enabled != prev_scan_enabled)
+  }
+  if (config_.scan_output.enabled != prev_scan_enabled) {
     changes.emplace_back(
       std::string("scan_output=") + (config_.scan_output.enabled ? "on" : "off"));
+  }
 
   output_pipeline_.configure(config_.cloud_output);
   scan_builder_.configure(config_.scan_output, config_.output_rate, config_.output_frame_id);
 
-  for (size_t i = 0; i < sources_.size() && i < config_.sources.size(); ++i)
+  for (size_t i = 0; i < sources_.size() && i < config_.sources.size(); ++i) {
     sources_[i]->rebuild_filters(config_.sources[i].filter_params);
+  }
 
   if (changes.empty()) {
     RCLCPP_INFO(get_logger(), "polka: reconfigured (filters only)");
   } else {
     std::string joined;
     for (size_t i = 0; i < changes.size(); ++i) {
-      if (i) joined += ", ";
+      if (i) {joined += ", ";}
       joined += changes[i];
     }
     RCLCPP_INFO(get_logger(), "polka: reconfigured — %s", joined.c_str());
@@ -486,8 +522,8 @@ void PolkaNode::log_startup_banner() const
       (sc.type == SourceType::POINTCLOUD2) ? "pointcloud2" : "laserscan  ";
     const auto & fp = sc.filter_params;
     int nfilters = (fp.range_filter_enabled ? 1 : 0) +
-                   (fp.angular_filter_enabled ? 1 : 0) +
-                   (fp.box_filter_enabled ? 1 : 0);
+      (fp.angular_filter_enabled ? 1 : 0) +
+      (fp.box_filter_enabled ? 1 : 0);
     os << "polka:     " << sc.name
        << "  " << type_str
        << "  '" << sc.topic << "'"

--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -13,22 +13,25 @@
 // limitations under the License.
 
 #include "polka/input/source_adapter.hpp"
-#include "polka/util/se3_exp.hpp"
-#include "polka/filters/filter_chain.hpp"
 
 #include <pcl_conversions/pcl_conversions.h>
-#include <sensor_msgs/msg/point_field.hpp>
-#include <tf2_eigen/tf2_eigen.hpp>
 
 #include <cstring>
 
-namespace polka {
+#include "polka/util/se3_exp.hpp"
+#include "polka/filters/filter_chain.hpp"
+#include <sensor_msgs/msg/point_field.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
 
-SourceAdapter::SourceAdapter(rclcpp::Node * node, const SourceConfig & config, bool gpu_filters,
-                             ImuGetter imu_getter, bool deskew_enabled,
-                             const std::string & timestamp_field_hint,
-                             std::shared_ptr<tf2_ros::Buffer> tf_buffer,
-                             int imu_buffer_size)
+namespace polka
+{
+
+SourceAdapter::SourceAdapter(
+  rclcpp::Node * node, const SourceConfig & config, bool gpu_filters,
+  ImuGetter imu_getter, bool deskew_enabled,
+  const std::string & timestamp_field_hint,
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+  int imu_buffer_size)
 : node_(node), config_(config), logger_(node->get_logger()), gpu_filters_(gpu_filters),
   get_imu_(std::move(imu_getter)), deskew_enabled_(deskew_enabled),
   timestamp_field_hint_(timestamp_field_hint), tf_buffer_(std::move(tf_buffer))
@@ -37,9 +40,10 @@ SourceAdapter::SourceAdapter(rclcpp::Node * node, const SourceConfig & config, b
   if (deskew_enabled_ && !config.imu_topic.empty()) {
     local_imu_ = std::make_shared<ImuBuffer>(node, config.imu_topic, imu_buffer_size);
     get_imu_ = [this]() -> std::shared_ptr<const AveragedImu> {
-      return local_imu_->snapshot();
-    };
-    RCLCPP_INFO(logger_, "polka: source '%s' using per-source IMU on '%s'",
+        return local_imu_->snapshot();
+      };
+    RCLCPP_INFO(
+      logger_, "polka: source '%s' using per-source IMU on '%s'",
       config.name.c_str(), config.imu_topic.c_str());
   }
   // Build QoS
@@ -61,10 +65,12 @@ SourceAdapter::SourceAdapter(rclcpp::Node * node, const SourceConfig & config, b
       std::bind(&SourceAdapter::scan_callback, this, std::placeholders::_1));
   }
 
-  if (!gpu_filters_)
+  if (!gpu_filters_) {
     filters_ = build_filter_chain(config.filter_params);
+  }
 
-  RCLCPP_INFO(logger_, "polka: source '%s' subscribed to '%s' (%s), %zu filters%s",
+  RCLCPP_INFO(
+    logger_, "polka: source '%s' subscribed to '%s' (%s), %zu filters%s",
     config.name.c_str(), config.topic.c_str(),
     config.type == SourceType::POINTCLOUD2 ? "PointCloud2" : "LaserScan",
     filters_.size(),
@@ -75,20 +81,28 @@ bool SourceAdapter::validate_fields(const sensor_msgs::msg::PointCloud2 & msg)
 {
   bool has_x = false, has_y = false, has_z = false, has_intensity = false;
   for (const auto & field : msg.fields) {
-    if (field.name == "x" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) has_x = true;
-    if (field.name == "y" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) has_y = true;
-    if (field.name == "z" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) has_z = true;
-    if (field.name == "intensity") has_intensity = true;
+    if (field.name == "x" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) {
+      has_x = true;
+    }
+    if (field.name == "y" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) {
+      has_y = true;
+    }
+    if (field.name == "z" && field.datatype == sensor_msgs::msg::PointField::FLOAT32) {
+      has_z = true;
+    }
+    if (field.name == "intensity") {has_intensity = true;}
   }
   if (!has_x || !has_y || !has_z) {
-    RCLCPP_ERROR(logger_,
+    RCLCPP_ERROR(
+      logger_,
       "polka: source '%s' missing required FLOAT32 x/y/z fields - dropping all messages",
       config_.name.c_str());
     return false;
   }
   missing_intensity_ = !has_intensity;
   if (missing_intensity_) {
-    RCLCPP_WARN(logger_,
+    RCLCPP_WARN(
+      logger_,
       "polka: source '%s' missing 'intensity' field - publishing with intensity=0",
       config_.name.c_str());
   }
@@ -116,11 +130,13 @@ void SourceAdapter::detect_timestamp_field(const sensor_msgs::msg::PointCloud2 &
     for (const auto & name : candidates) {
       if (field.name == name) {
         if (field.datatype == sensor_msgs::msg::PointField::FLOAT32 ||
-            field.datatype == sensor_msgs::msg::PointField::FLOAT64) {
+          field.datatype == sensor_msgs::msg::PointField::FLOAT64)
+        {
           has_timestamp_field_ = true;
           timestamp_field_offset_ = field.offset;
           timestamp_field_datatype_ = field.datatype;
-          RCLCPP_INFO(logger_,
+          RCLCPP_INFO(
+            logger_,
             "polka: source '%s' detected per-point timestamp field '%s' (offset=%u, %s)",
             config_.name.c_str(), field.name.c_str(), field.offset,
             field.datatype == sensor_msgs::msg::PointField::FLOAT64 ? "FLOAT64" : "FLOAT32");
@@ -130,7 +146,8 @@ void SourceAdapter::detect_timestamp_field(const sensor_msgs::msg::PointCloud2 &
     }
   }
 
-  RCLCPP_INFO(logger_,
+  RCLCPP_INFO(
+    logger_,
     "polka: source '%s' has no per-point timestamp field, per-point deskewing disabled",
     config_.name.c_str());
 }
@@ -158,9 +175,11 @@ void SourceAdapter::populate_point_time(
   // No per-point field (or layout we cannot index safely): every point inherits
   // the message header stamp. Same fallback used for projected LaserScan sources.
   if (!has_timestamp_field_ ||
-      n != static_cast<size_t>(raw_msg.width) * raw_msg.height) {
-    for (size_t i = 0; i < n; ++i)
+    n != static_cast<size_t>(raw_msg.width) * raw_msg.height)
+  {
+    for (size_t i = 0; i < n; ++i) {
       cloud[i].time = header_sec;
+    }
     return;
   }
 
@@ -181,13 +200,13 @@ void SourceAdapter::deskew_cloud(
   const AveragedImu & imu)
 {
   size_t n = cloud.size();
-  if (n == 0 || n != static_cast<size_t>(raw_msg.width) * raw_msg.height) return;
+  if (n == 0 || n != static_cast<size_t>(raw_msg.width) * raw_msg.height) {return;}
 
   // Rotate IMU data from IMU frame into sensor frame (identity if same frame or TF unavailable)
   Eigen::Matrix3d R_imu_to_sensor = Eigen::Matrix3d::Identity();
   if (tf_buffer_ && !imu.frame_id.empty()) {
     std::string sensor_frame;
-    { std::lock_guard<std::mutex> lock(meta_mutex_); sensor_frame = frame_id_; }
+    {std::lock_guard<std::mutex> lock(meta_mutex_); sensor_frame = frame_id_;}
     if (!sensor_frame.empty() && sensor_frame != imu.frame_id) {
       try {
         auto tf_msg = tf_buffer_->lookupTransform(
@@ -212,7 +231,7 @@ void SourceAdapter::deskew_cloud(
     // Interpret: if >1e8 it's absolute Unix time, otherwise relative offset from scan start
     double dt = (pt_time > 1e8) ? (pt_time - header_sec) : pt_time;
 
-    if (std::abs(dt) < 1e-9) continue;
+    if (std::abs(dt) < 1e-9) {continue;}
 
     Eigen::Isometry3d delta = compute_motion_delta(angular_vel, accel, dt);
     Eigen::Vector3d p(cloud[i].x, cloud[i].y, cloud[i].z);
@@ -249,11 +268,12 @@ void SourceAdapter::pc2_callback(sensor_msgs::msg::PointCloud2::ConstSharedPtr m
     fields_validated_ = true;
     fields_valid_ = validate_fields(*msg);
   }
-  if (!fields_valid_) return;
+  if (!fields_valid_) {return;}
 
   // Detect per-point timestamp field on first message
-  if (!timestamp_field_detected_)
+  if (!timestamp_field_detected_) {
     detect_timestamp_field(*msg);
+  }
 
   auto cloud = std::make_shared<CloudT>();
   pcl::fromROSMsg(*msg, *cloud);
@@ -265,8 +285,7 @@ void SourceAdapter::pc2_callback(sensor_msgs::msg::PointCloud2::ConstSharedPtr m
   // Per-point deskewing (before filters, in sensor frame)
   if (deskew_enabled_ && has_timestamp_field_ && get_imu_) {
     auto imu = get_imu_();
-    if (imu && imu->valid)
-      deskew_cloud(*cloud, *msg, *imu);
+    if (imu && imu->valid) {deskew_cloud(*cloud, *msg, *imu);}
   }
 
   apply_filters(*cloud);
@@ -283,7 +302,7 @@ void SourceAdapter::scan_callback(sensor_msgs::msg::LaserScan::ConstSharedPtr ms
     fields_validated_ = true;
     fields_valid_ = validate_fields(pc2_msg);
   }
-  if (!fields_valid_) return;
+  if (!fields_valid_) {return;}
 
   auto cloud = std::make_shared<CloudT>();
   pcl::fromROSMsg(pc2_msg, *cloud);
@@ -306,7 +325,7 @@ std::string SourceAdapter::frame_id() const
 
 bool SourceAdapter::is_stale(double timeout_sec, const rclcpp::Time & now) const
 {
-  if (!has_received_.load()) return true;
+  if (!has_received_.load()) {return true;}
   std::lock_guard<std::mutex> lock(meta_mutex_);
   return (now - last_received_time_).seconds() > timeout_sec;
 }
@@ -321,8 +340,9 @@ void SourceAdapter::rebuild_filters(const FilterParams & fp)
 {
   config_.filter_params = fp;
   filters_.clear();
-  if (!gpu_filters_)
+  if (!gpu_filters_) {
     filters_ = build_filter_chain(fp);
+  }
 }
 
 }  // namespace polka


### PR DESCRIPTION
Fixes pre existing lint failures on humble, unrelated to any feature work. Every PR into humble inherits these through the merge ref CI check regardless of what it changes.

* doc/media Python scripts: unused import, flake8 E702 semicolon splits, E501 line length, pep257 D213 docstring convention
* C++ sources: cpplint header guard and include order (own header, C system, C++ system, other), ament_uncrustify formatting
* No behavior change anywhere, verified locally in a fresh humble desktop container: build succeeds, all 7 lint and test categories pass with 0 failures