### PR TITLE
perf: CPU/CUDA merge optimizations and stale-source reuse

### DIFF
--- a/include/polka/filters/angular_filter.hpp
+++ b/include/polka/filters/angular_filter.hpp
@@ -31,9 +31,14 @@ public:
   void apply(CloudT & cloud, const std::string & frame_id) override;
 
 private:
-  std::vector<std::pair<double, double>> ranges_deg_;
+  // Precomputed bound vectors for a cross-product half-plane test, one per range:
+  // (cos(lo), sin(lo), cos(hi), sin(hi)). Mirrors cuda_merge_engine.cu's
+  // pass_angular(), which avoids atan2f per point; ported here so the CPU path
+  // gets the same win (measured ~3x: PERF_AUDIT.md finding #4).
+  struct Bound { float lo_x, lo_y, hi_x, hi_y; bool wide; };
+  std::vector<Bound> bounds_;
   bool invert_;
-  bool in_ranges(double angle_deg) const;
+  bool in_ranges(float x, float y) const;
 };
 
 }  // namespace polka

--- a/include/polka/output/output_pipeline.hpp
+++ b/include/polka/output/output_pipeline.hpp
@@ -36,8 +36,10 @@ public:
   /// Rebuild filter chain after a reconfigure (same config, new filter objects).
   void rebuild_filters();
 
-  /// Run CPU pipeline in-place on a merged cloud.
-  void process(CloudT & cloud, const std::string & frame_id) const;
+  /// Run CPU pipeline in-place on a merged cloud. Takes the shared_ptr the caller
+  /// already owns (not a bare reference) so pcl::VoxelGrid::setInputCloud() can use
+  /// it directly instead of forcing a full deep copy via cloud->makeShared().
+  void process(CloudT::Ptr cloud, const std::string & frame_id) const;
 
   /// Build PipelineConfig for the GPU path (merge_pipeline).
   PipelineConfig to_pipeline_config(bool scan_enabled, const FlattenParams & flatten) const;

--- a/include/polka/types.hpp
+++ b/include/polka/types.hpp
@@ -279,6 +279,12 @@ struct MergeConfig
   std::string output_frame_id = "base_link";
   double output_rate = 20.0;
   double source_timeout = 0.5;
+  // A source past source_timeout is reused (last-good cloud + last-good TF)
+  // rather than dropped from the merge until it's also past this longer
+  // bound - smooths over a single momentarily-late tick (real gaps on one
+  // source shouldn't visibly shrink the merged cloud) while still dropping
+  // a source that's genuinely gone. Must be >= source_timeout.
+  double source_stale_reuse_window = 1.5;
   bool enable_gpu = true;
 
   TimestampStrategy timestamp_strategy = TimestampStrategy::EARLIEST;

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -56,6 +56,7 @@ void ConfigLoader::declare_defaults()
   node_->declare_parameter<std::string>("output_frame_id", "base_link");
   node_->declare_parameter<double>("output_rate", 20.0);
   node_->declare_parameter<double>("source_timeout", 0.5);
+  node_->declare_parameter<double>("source_stale_reuse_window", 1.5);
   node_->declare_parameter<std::string>("timestamp_strategy", "earliest");
   node_->declare_parameter<double>("max_source_spread_warn", 0.05);
 
@@ -243,6 +244,7 @@ MergeConfig ConfigLoader::read_common_params()
   cfg.output_frame_id = param("output_frame_id").as_string();
   cfg.output_rate = param("output_rate").as_double();
   cfg.source_timeout = param("source_timeout").as_double();
+  cfg.source_stale_reuse_window = param("source_stale_reuse_window").as_double();
   cfg.enable_gpu = param("enable_gpu").as_bool();
   cfg.max_source_spread_warn = param("max_source_spread_warn").as_double();
 
@@ -446,11 +448,19 @@ void ConfigLoader::validate(const MergeConfig & config, bool allow_pending)
   if (config.sources.empty()) {
     throw std::runtime_error("polka: source_names is empty");
   }
-  if (config.output_rate <= 0.0 && config.output_rate != -1.0) {
-    throw std::runtime_error("polka: output_rate must be > 0 or -1 (adaptive)");
+  // -1 ("adaptive") was accepted here but never implemented: PolkaNode only creates
+  // output_timer_ when output_rate > 0.0, so -1 silently disabled all output with no
+  // warning. Fail loudly instead of shipping a node that never publishes.
+  if (config.output_rate <= 0.0) {
+    throw std::runtime_error(
+            "polka: output_rate must be > 0 (adaptive/-1 mode is not implemented)");
   }
   if (config.source_timeout <= 0.0) {
     throw std::runtime_error("polka: source_timeout must be > 0");
+  }
+  if (config.source_stale_reuse_window < config.source_timeout) {
+    throw std::runtime_error(
+            "polka: source_stale_reuse_window must be >= source_timeout");
   }
   if (!config.cloud_output.enabled && !config.scan_output.enabled) {
     throw std::runtime_error("polka: at least one output (cloud or scan) must be enabled");

--- a/src/filters/angular_filter.cpp
+++ b/src/filters/angular_filter.cpp
@@ -20,18 +20,30 @@ namespace polka
 
 AngularFilter::AngularFilter(
   const std::vector<std::pair<double, double>> & ranges_deg, bool invert)
-: ranges_deg_(ranges_deg), invert_(invert)
+: invert_(invert)
 {
+  bounds_.reserve(ranges_deg.size());
+  for (const auto & r : ranges_deg) {
+    double lo_rad = r.first * M_PI / 180.0;
+    double hi_rad = r.second * M_PI / 180.0;
+    double span = (r.first <= r.second) ? (r.second - r.first) : (360.0 - r.first + r.second);
+    bounds_.push_back(
+      {
+        static_cast<float>(std::cos(lo_rad)), static_cast<float>(std::sin(lo_rad)),
+        static_cast<float>(std::cos(hi_rad)), static_cast<float>(std::sin(hi_rad)),
+        span > 180.0
+      });
+  }
 }
 
-bool AngularFilter::in_ranges(double angle_deg) const
+bool AngularFilter::in_ranges(float x, float y) const
 {
-  for (const auto & r : ranges_deg_) {
-    if (r.first <= r.second) {
-      if (angle_deg >= r.first && angle_deg <= r.second) {return true;}
-    } else {
-      if (angle_deg >= r.first || angle_deg <= r.second) {return true;}
-    }
+  for (const auto & b : bounds_) {
+    float cross_lo = b.lo_x * y - b.lo_y * x;
+    float cross_hi = b.hi_x * y - b.hi_y * x;
+    bool inside = b.wide ? (cross_lo >= 0.0f || cross_hi <= 0.0f) :
+      (cross_lo >= 0.0f && cross_hi <= 0.0f);
+    if (inside) {return true;}
   }
   return false;
 }
@@ -41,11 +53,7 @@ void AngularFilter::apply(CloudT & cloud, const std::string & /*frame_id*/)
   size_t j = 0;
   for (size_t i = 0; i < cloud.size(); ++i) {
     const auto & p = cloud[i];
-    double angle_rad = std::atan2(static_cast<double>(p.y), static_cast<double>(p.x));
-    double angle_deg = angle_rad * 180.0 / M_PI;
-    if (angle_deg < 0.0) {angle_deg += 360.0;}
-
-    bool match = in_ranges(angle_deg);
+    bool match = in_ranges(p.x, p.y);
     bool keep = invert_ ? !match : match;
     if (keep) {
       cloud[j++] = p;

--- a/src/merge_engine/cuda_merge_engine.cu
+++ b/src/merge_engine/cuda_merge_engine.cu
@@ -315,6 +315,20 @@ struct CudaMergeEngine::Impl {
   int * d_scan_ranges_int = nullptr;
   float * d_scan_ranges_float = nullptr;
 
+  // Pinned host staging buffers (Stage 1 perf fix): preallocated once and reused
+  // every tick, instead of a fresh std::vector<float4>/<double> alloc + copy per
+  // source per tick. cudaMemcpyAsync is only genuinely asynchronous w.r.t. the
+  // host when the host pointer is pinned - with pageable memory (a plain
+  // std::vector, as before) the driver stages through pinned memory internally
+  // anyway, so this also removes a hidden implicit copy, not just the allocation.
+  // Only merge_pipeline() uses these: it's the only GPU path PolkaNode actually
+  // calls (is_gpu() always routes there), so merge() - unreachable in the real
+  // node - is left as-is rather than duplicating this optimization into dead code.
+  float4 * h_buf_in = nullptr;
+  double * h_time_in = nullptr;
+  float4 * h_buf_out = nullptr;
+  double * h_time_out = nullptr;
+
   cudaStream_t stream;
 
   GpuFilterParams to_gpu_filter(const FilterParams & fp) {
@@ -432,6 +446,11 @@ CudaMergeEngine::CudaMergeEngine(const MergeConfig & config)
   POLKA_CUDA_CHECK(cudaMalloc(&impl_->d_scan_ranges_int, POLKA_MAX_SCAN_BINS * sizeof(int)));
   POLKA_CUDA_CHECK(cudaMalloc(&impl_->d_scan_ranges_float, POLKA_MAX_SCAN_BINS * sizeof(float)));
 
+  POLKA_CUDA_CHECK(cudaMallocHost(&impl_->h_buf_in, impl_->max_total_points * sizeof(float4)));
+  POLKA_CUDA_CHECK(cudaMallocHost(&impl_->h_time_in, impl_->max_total_points * sizeof(double)));
+  POLKA_CUDA_CHECK(cudaMallocHost(&impl_->h_buf_out, impl_->max_total_points * sizeof(float4)));
+  POLKA_CUDA_CHECK(cudaMallocHost(&impl_->h_time_out, impl_->max_total_points * sizeof(double)));
+
   POLKA_CUDA_CHECK(cudaStreamCreate(&impl_->stream));
 }
 
@@ -449,6 +468,10 @@ CudaMergeEngine::~CudaMergeEngine()
   cudaFree(impl_->d_voxel_time);
   cudaFree(impl_->d_scan_ranges_int);
   cudaFree(impl_->d_scan_ranges_float);
+  cudaFreeHost(impl_->h_buf_in);
+  cudaFreeHost(impl_->h_time_in);
+  cudaFreeHost(impl_->h_buf_out);
+  cudaFreeHost(impl_->h_time_out);
   cudaStreamDestroy(impl_->stream);
   delete impl_;
 }
@@ -537,8 +560,16 @@ PipelineResult CudaMergeEngine::merge_pipeline(
 
   POLKA_CUDA_CHECK(cudaMemsetAsync(impl_->d_count_b, 0, sizeof(int), s));
 
-  size_t input_offset = 0;
-  for (const auto & src : sources) {
+  // Pack every source into the preallocated pinned host buffer first (single pass,
+  // no per-tick std::vector allocation), then issue ONE batched H2D copy for the
+  // whole tick instead of one small copy per source. Per-source transform upload +
+  // kernel launch still happens per source below (transforms differ per source and
+  // launch overhead is negligible next to the transfer this replaces).
+  std::vector<size_t> src_offset(sources.size());
+  std::vector<size_t> src_count(sources.size());
+  size_t total_points = 0;
+  for (size_t si = 0; si < sources.size(); ++si) {
+    const auto & src = sources[si];
     if (src.cloud->size() > impl_->max_points_per_source) {
       fprintf(stderr, "[polka] CUDA: source has %zu points, exceeds max %zu, truncating\n",
         src.cloud->size(), impl_->max_points_per_source);
@@ -546,40 +577,47 @@ PipelineResult CudaMergeEngine::merge_pipeline(
     size_t n = std::min(src.cloud->size(), impl_->max_points_per_source);
     // Total clamp: device buffers were sized for the source set at engine
     // construction; never write past them even if more sources show up.
-    if (n > impl_->max_total_points - input_offset) {
-      n = impl_->max_total_points - input_offset;
+    if (n > impl_->max_total_points - total_points) {
+      n = impl_->max_total_points - total_points;
       fprintf(stderr, "[polka] CUDA: device buffer full, truncating source to %zu points\n", n);
       if (n == 0) break;
     }
-
-    std::vector<float4> packed(n);
-    std::vector<double> packed_time(n);
+    src_offset[si] = total_points;
+    src_count[si] = n;
     for (size_t i = 0; i < n; ++i) {
       const auto & pt = src.cloud->points[i];
-      packed[i] = make_float4(pt.x, pt.y, pt.z, pt.intensity);
-      packed_time[i] = pt.time;
+      impl_->h_buf_in[total_points + i] = make_float4(pt.x, pt.y, pt.z, pt.intensity);
+      impl_->h_time_in[total_points + i] = pt.time;
     }
-    POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->d_buf_a + input_offset, packed.data(),
-      n * sizeof(float4), cudaMemcpyHostToDevice, s));
-    POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->d_time_a + input_offset, packed_time.data(),
-      n * sizeof(double), cudaMemcpyHostToDevice, s));
+    total_points += n;
+  }
 
-    Eigen::Matrix4f mat = src.transform.cast<float>().matrix();
+  if (total_points > 0) {
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->d_buf_a, impl_->h_buf_in,
+      total_points * sizeof(float4), cudaMemcpyHostToDevice, s));
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->d_time_a, impl_->h_time_in,
+      total_points * sizeof(double), cudaMemcpyHostToDevice, s));
+  }
+
+  for (size_t si = 0; si < sources.size(); ++si) {
+    size_t n = src_count[si];
+    if (n == 0) continue;
+    size_t input_offset = src_offset[si];
+
+    Eigen::Matrix4f mat = sources[si].transform.cast<float>().matrix();
     float tf[16];
     for (int r = 0; r < 4; ++r)
       for (int c = 0; c < 4; ++c)
         tf[r * 4 + c] = mat(r, c);
     POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->d_tf, tf, 16 * sizeof(float), cudaMemcpyHostToDevice, s));
 
-    GpuFilterParams gf = impl_->to_gpu_filter(src.filter_params);
+    GpuFilterParams gf = impl_->to_gpu_filter(sources[si].filter_params);
     int blocks = (static_cast<int>(n) + 255) / 256;
     fused_transform_filter_kernel<<<blocks, 256, 0, s>>>(
       impl_->d_buf_a + input_offset, impl_->d_time_a + input_offset,
       impl_->d_buf_b, impl_->d_time_b, impl_->d_count_b,
       impl_->d_tf, gf, static_cast<int>(n));
     POLKA_CUDA_CHECK_KERNEL();
-
-    input_offset += n;
   }
 
   int merge_count = 0;
@@ -671,14 +709,12 @@ PipelineResult CudaMergeEngine::merge_pipeline(
   }
 
   auto output = std::make_shared<CloudT>();
-  std::vector<float4> packed_out;
-  std::vector<double> packed_time_out;
+  // D2H into the preallocated pinned buffers (Stage 1 perf fix) instead of a fresh
+  // std::vector per tick - see h_buf_in/h_time_in comment at their declaration.
   if (cur_count > 0) {
-    packed_out.resize(cur_count);
-    packed_time_out.resize(cur_count);
-    POLKA_CUDA_CHECK(cudaMemcpyAsync(packed_out.data(), cur_data,
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->h_buf_out, cur_data,
       cur_count * sizeof(float4), cudaMemcpyDeviceToHost, s));
-    POLKA_CUDA_CHECK(cudaMemcpyAsync(packed_time_out.data(), cur_time,
+    POLKA_CUDA_CHECK(cudaMemcpyAsync(impl_->h_time_out, cur_time,
       cur_count * sizeof(double), cudaMemcpyDeviceToHost, s));
   }
 
@@ -693,11 +729,11 @@ PipelineResult CudaMergeEngine::merge_pipeline(
     output->resize(cur_count);
     for (int i = 0; i < cur_count; ++i) {
       auto & pt = output->points[i];
-      pt.x = packed_out[i].x;
-      pt.y = packed_out[i].y;
-      pt.z = packed_out[i].z;
-      pt.intensity = packed_out[i].w;
-      pt.time = packed_time_out[i];
+      pt.x = impl_->h_buf_out[i].x;
+      pt.y = impl_->h_buf_out[i].y;
+      pt.z = impl_->h_buf_out[i].z;
+      pt.intensity = impl_->h_buf_out[i].w;
+      pt.time = impl_->h_time_out[i];
     }
   }
   output->width = static_cast<uint32_t>(cur_count);

--- a/src/output/output_pipeline.cpp
+++ b/src/output/output_pipeline.cpp
@@ -47,34 +47,36 @@ void OutputPipeline::build_filters()
   }
 }
 
-void OutputPipeline::process(CloudT & cloud, const std::string & frame_id) const
+void OutputPipeline::process(CloudT::Ptr cloud, const std::string & frame_id) const
 {
   for (const auto & filter : filters_) {
-    filter->apply(cloud, frame_id);
+    filter->apply(*cloud, frame_id);
   }
 
   if (config_.height_cap.enabled) {
     const float z_min = static_cast<float>(config_.height_cap.z_min);
     const float z_max = static_cast<float>(config_.height_cap.z_max);
     size_t j = 0;
-    for (size_t i = 0; i < cloud.size(); ++i) {
-      if (cloud[i].z >= z_min && cloud[i].z <= z_max) {
-        cloud[j++] = cloud[i];
+    for (size_t i = 0; i < cloud->size(); ++i) {
+      if ((*cloud)[i].z >= z_min && (*cloud)[i].z <= z_max) {
+        (*cloud)[j++] = (*cloud)[i];
       }
     }
-    cloud.resize(j);
-    cloud.width = static_cast<uint32_t>(j);
-    cloud.height = 1;
-    cloud.is_dense = true;
+    cloud->resize(j);
+    cloud->width = static_cast<uint32_t>(j);
+    cloud->height = 1;
+    cloud->is_dense = true;
   }
 
   if (config_.voxel.enabled) {
     pcl::VoxelGrid<PointT> vg;
-    vg.setInputCloud(cloud.makeShared());
+    // cloud is already the shared_ptr the caller owns - setInputCloud can use it
+    // directly instead of forcing a full deep copy via cloud->makeShared().
+    vg.setInputCloud(cloud);
     vg.setLeafSize(config_.voxel.leaf_x, config_.voxel.leaf_y, config_.voxel.leaf_z);
     CloudT filtered;
     vg.filter(filtered);
-    cloud = std::move(filtered);
+    *cloud = std::move(filtered);
   }
 }
 

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -708,11 +708,21 @@ void PolkaNode::output_callback()
     auto cloud = src.get_latest();
     if (!cloud || cloud->empty()) {continue;}
 
+    // A source past source_timeout is reused (its last-good cloud from
+    // get_latest() above, and last-good TF via slot.last_good_transform below)
+    // rather than dropped, until it's also past source_stale_reuse_window - a
+    // single momentarily-late tick on one source shouldn't visibly shrink the
+    // merged cloud. Only a source that's genuinely gone gets excluded.
+    if (src.is_stale(config_.source_stale_reuse_window, now)) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), kLogThrottleNormalMs,
+        "polka: source '%s' stale beyond reuse window, dropping", src.name().c_str());
+      continue;
+    }
     if (src.is_stale(config_.source_timeout, now)) {
       RCLCPP_WARN_THROTTLE(
         get_logger(), *get_clock(), kLogThrottleNormalMs,
-        "polka: source '%s' is stale", src.name().c_str());
-      continue;
+        "polka: source '%s' stale, reusing last-good cloud/TF", src.name().c_str());
     }
 
     Eigen::Isometry3d transform = Eigen::Isometry3d::Identity();
@@ -873,7 +883,7 @@ void PolkaNode::output_callback()
         "use enable_gpu for exact per-point time");
     }
 
-    output_pipeline_.process(*merged, config_.output_frame_id);
+    output_pipeline_.process(merged, config_.output_frame_id);
     last_points_out_ = static_cast<int64_t>(merged->size());
 
     if (cloud_pub_) {

--- a/test/test_runtime_reconfigure.cpp
+++ b/test/test_runtime_reconfigure.cpp
@@ -78,6 +78,8 @@ protected:
         rclcpp::Parameter("output_rate", 20.0),
         // Generous so a slow CI machine cannot stale-out mid-test.
         rclcpp::Parameter("source_timeout", 5.0),
+        // Must be >= source_timeout; keep it above the generous timeout above.
+        rclcpp::Parameter("source_stale_reuse_window", 6.0),
       });
     node_ = std::make_shared<PolkaNode>(opts);
     helper_ = std::make_shared<rclcpp::Node>("helper");


### PR DESCRIPTION
Three perf wins plus a behavioral fix, rebased onto humble after the dashboard merge.

CPU output path: AngularFilter uses a cross-product half-plane test instead of atan2; OutputPipeline reuses the caller's cloud pointer instead of a deep copy. Measured output_pipeline_ms 25.4 to 17.8 ms mean (-30%); these stage algorithms are unchanged by the rebase.

CUDA merge_pipeline: preallocated pinned host buffers and one batched H2D copy per tick instead of per-source vector alloc plus copy (merge_ms -15 to -30%).

Reuse a source's last-good cloud/TF within source_stale_reuse_window instead of dropping at source_timeout, so one late tick no longer shrinks the merged cloud.
