### PR TITLE
release prep v0.5.0: cleanup + version bump

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,19 @@ Forthcoming
 * Consolidate documentation assets (docs, images, demo media) under ``doc/``.
 * Remove the superseded ``pipeline_demo.gif``.
 
+0.5.0 (2026-07-25)
+------------------
+* Add ``polka_monitor`` terminal diagnostics dashboard and ``dashboard`` launch arg.
+* Two-phase runtime reconfigure and ``/diagnostics`` stats with timing and rate drift flags.
+* CPU and CUDA merge performance optimizations, plus bounded stale-source reuse.
+* Coarse-stride SE(3) rotation interpolation for faster per-point deskew.
+* Estimate body-frame gravity via EMA when the IMU lacks orientation.
+* Detect rosbag/clock misconfiguration and expose ``use_sim_time``.
+* Per-point timestamp passthrough with a duplicate-timestamp guard.
+* Add Iron, Kilted, and Lyrical distro support with a per-distro CI build matrix.
+* Behavior change: ``suppress_duplicate_timestamps`` and ``diagnostics.enabled`` now default to true.
+* ``example_params.yaml`` slimmed to a minimal example; full reference moved to ``config/detailed_params.yaml``.
+
 0.3.0 (2026-05-28)
 ------------------
 * Add CHANGELOG.rst (REP 132) and release metadata to package.xml (website / repository / bugtracker URLs, author tag); bump version to 0.3.0.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,8 @@ Forthcoming
 * Add ``polka_monitor`` terminal diagnostics dashboard and ``dashboard`` launch arg.
 * Two-phase runtime reconfigure and ``/diagnostics`` stats with timing and rate drift flags.
 * CPU and CUDA merge performance optimizations, plus bounded stale-source reuse.
-* Coarse-stride SE(3) rotation interpolation for faster per-point deskew.
+* CPU angular filter replaces per-point atan2 with a precomputed cross-product half-plane test, about 3x faster (10.47 to 3.55 ms per tick at 259k points).
+* Coarse-stride SE(3) rotation interpolation cuts per-source deskew latency from ~9.8 ms to ~1.6 ms (about 6.2x) with negligible accuracy loss (max error ~1.6e-7 cm).
 * Estimate body-frame gravity via EMA when the IMU lacks orientation.
 * Detect rosbag/clock misconfiguration and expose ``use_sim_time``.
 * Per-point timestamp passthrough with a duplicate-timestamp guard.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,13 +2,6 @@
 Changelog for package polka
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
-* Add per-feature demo GIFs (multi-LiDAR fusion, output filters, angular invert, self-filter, voxel downsample, dual output, 2D scan merge) generated from the TIERS multi-LiDAR dataset with a headless Open3D + gifski toolchain.
-* Slim the README to badges, demo gallery, and quick start; move parameter and pipeline detail into ``doc/CONFIGURATION.md`` and ``doc/PIPELINE.md``.
-* Consolidate documentation assets (docs, images, demo media) under ``doc/``.
-* Remove the superseded ``pipeline_demo.gif``.
-
 0.5.0 (2026-07-25)
 ------------------
 * Add ``polka_monitor`` terminal diagnostics dashboard and ``dashboard`` launch arg.
@@ -20,7 +13,12 @@ Forthcoming
 * Detect rosbag/clock misconfiguration and expose ``use_sim_time``.
 * Per-point timestamp passthrough with a duplicate-timestamp guard.
 * Add Iron, Kilted, and Lyrical distro support with a per-distro CI build matrix.
+* Modular refactor of the node internals: headers reorganized into subdirectories, with the output path split into ``OutputPipeline`` and ``ScanBuilder``.
 * Behavior change: ``suppress_duplicate_timestamps`` and ``diagnostics.enabled`` now default to true.
+* Add per-feature demo GIFs (multi-LiDAR fusion, output filters, angular invert, self-filter, voxel downsample, dual output, 2D scan merge) generated from the TIERS multi-LiDAR dataset with a headless Open3D + gifski toolchain.
+* Slim the README to badges, demo gallery, and quick start; move parameter and pipeline detail into ``doc/CONFIGURATION.md`` and ``doc/PIPELINE.md``.
+* Consolidate documentation assets (docs, images, demo media) under ``doc/``.
+* Remove the superseded ``pipeline_demo.gif``.
 * ``example_params.yaml`` slimmed to a minimal example; full reference moved to ``config/detailed_params.yaml``.
 
 0.3.0 (2026-05-28)

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Each clip runs polka with a different config on the [TIERS multi-LiDAR dataset](
 - **IMU deskewing**: per-point SE(3) motion correction, with per-point timestamp auto-detect
 - **CUDA acceleration**: optional GPU merge engine, falls back to CPU
 - **TF2 integration**: automatic lookup with last-known-good fallback
-- **Full runtime reconfiguration**: filters, outputs, deskewing, and even the source list can be changed live via `ros2 param set` — no restart (see [Runtime Reconfiguration & Diagnostics](doc/RUNTIME.md))
-- **Diagnostics, drift detection, and a terminal dashboard**: per-source rate/bandwidth/lag on `/diagnostics`, timing/rate drift flags, and an optional `polka_monitor` TUI (see [Runtime Reconfiguration & Diagnostics](doc/RUNTIME.md))
+- **Full runtime reconfiguration**: filters, outputs, deskewing, and even the source list can be changed live via `ros2 param set` — no restart
+- **Diagnostics, drift detection, and a terminal dashboard**: per-source rate/bandwidth/lag on `/diagnostics`, timing/rate drift flags, and an optional `polka_monitor` TUI
 - **Composable node**: runs standalone or loaded into a component container
 
 ## Install
@@ -102,7 +102,6 @@ Set `output_frame_id` to your base frame, list sensors under `source_names`, and
 ## Documentation
 
 - **[Configuration](doc/CONFIGURATION.md)**: every parameter, filters, IMU deskewing, rosbag playback
-- **[Runtime Reconfiguration & Diagnostics](doc/RUNTIME.md)**: live `ros2 param set` reconfiguration, `/diagnostics`, drift detection, the `polka_monitor` terminal dashboard
 - **[Pipeline and architecture](doc/PIPELINE.md)**: what polka replaces, internal stages, file layout
 - **[Maintaining distro branches](MAINTAINING.md)**: single-source-of-truth sync across the five branches
 

--- a/include/polka/config/config_loader.hpp
+++ b/include/polka/config/config_loader.hpp
@@ -63,7 +63,7 @@ private:
   FilterParams load_filter_params(const std::string & prefix);
   OutputQosConfig load_output_qos(const std::string & prefix);
   SelfFilterConfig load_self_filter_config(const std::string & prefix, bool declare_missing);
-  void validate(const MergeConfig & config, bool allow_pending);
+  void validate(MergeConfig & config, bool allow_pending);
 
   // overlay -> committed storage; throws if the parameter was never declared.
   rclcpp::Parameter param(const std::string & name) const;

--- a/include/polka/filters/angular_filter.hpp
+++ b/include/polka/filters/angular_filter.hpp
@@ -34,7 +34,7 @@ private:
   // Precomputed bound vectors for a cross-product half-plane test, one per range:
   // (cos(lo), sin(lo), cos(hi), sin(hi)). Mirrors cuda_merge_engine.cu's
   // pass_angular(), which avoids atan2f per point; ported here so the CPU path
-  // gets the same win (measured ~3x: PERF_AUDIT.md finding #4).
+  // gets the same win (measured ~3x).
   struct Bound { float lo_x, lo_y, hi_x, hi_y; bool wide; };
   std::vector<Bound> bounds_;
   bool invert_;

--- a/include/polka/input/source_adapter.hpp
+++ b/include/polka/input/source_adapter.hpp
@@ -121,11 +121,6 @@ private:
   // Per-source IMU (when configured) and TF for frame rotation
   std::shared_ptr<ImuBuffer> local_imu_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
-
-  // Perf instrumentation: rolling deskew-loop latency, logged every N calls.
-  uint64_t deskew_calls_{0};
-  double deskew_total_us_{0.0};
-  double deskew_max_us_{0.0};
 };
 
 }  // namespace polka

--- a/include/polka/polka_node.hpp
+++ b/include/polka/polka_node.hpp
@@ -74,9 +74,6 @@ private:
   // single actionable warning when they don't (the classic rosbag-without-sim-time or
   // sim-time-without-/clock misconfiguration), then latches via clock_diagnosed_.
   void diagnose_clock_health(const rclcpp::Time & now);
-  // Perf instrumentation: accumulates merge-stage latency, logs a mean/max every
-  // N calls. `engine_label` is just "CPU" or "CUDA" for the log line.
-  void log_merge_perf(double us, const char * engine_label);
 
   // --- Two-phase runtime reconfiguration ---
   // Humble's on-set callback fires BEFORE the proposed values are committed to
@@ -130,11 +127,6 @@ private:
 
   // Set once diagnose_clock_health() has emitted its warning, so it stays quiet after.
   bool clock_diagnosed_{false};
-
-  // Perf instrumentation: rolling merge-stage latency, logged every N calls.
-  uint64_t merge_calls_{0};
-  double merge_total_us_{0.0};
-  double merge_max_us_{0.0};
 
   // Runtime reconfiguration.
   //

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>polka</name>
-  <version>0.3.0</version>
+  <version>0.5.0</version>
   <description>ROS2 composable node for multi-LiDAR fusion with optional CUDA acceleration.</description>
   <maintainer email="praajarpit@gmail.com">Panav Arpit Raaj</maintainer>
   <license>Apache-2.0</license>

--- a/src/config_loader.cpp
+++ b/src/config_loader.cpp
@@ -443,7 +443,7 @@ SelfFilterConfig ConfigLoader::load_self_filter_config(
   return sf;
 }
 
-void ConfigLoader::validate(const MergeConfig & config, bool allow_pending)
+void ConfigLoader::validate(MergeConfig & config, bool allow_pending)
 {
   if (config.sources.empty()) {
     throw std::runtime_error("polka: source_names is empty");
@@ -459,8 +459,12 @@ void ConfigLoader::validate(const MergeConfig & config, bool allow_pending)
     throw std::runtime_error("polka: source_timeout must be > 0");
   }
   if (config.source_stale_reuse_window < config.source_timeout) {
-    throw std::runtime_error(
-            "polka: source_stale_reuse_window must be >= source_timeout");
+    RCLCPP_WARN(
+      logger_,
+      "polka: source_stale_reuse_window (%.3f) < source_timeout (%.3f); "
+      "raising it to source_timeout",
+      config.source_stale_reuse_window, config.source_timeout);
+    config.source_stale_reuse_window = config.source_timeout;
   }
   if (!config.cloud_output.enabled && !config.scan_output.enabled) {
     throw std::runtime_error("polka: at least one output (cloud or scan) must be enabled");

--- a/src/merge_engine/cuda_merge_engine.cu
+++ b/src/merge_engine/cuda_merge_engine.cu
@@ -492,7 +492,11 @@ CloudT::Ptr CudaMergeEngine::merge(const std::vector<MergeInput> & sources)
     // construction; never write past them even if more sources show up.
     if (n > impl_->max_total_points - input_offset) {
       n = impl_->max_total_points - input_offset;
-      fprintf(stderr, "[polka] CUDA: device buffer full, truncating source to %zu points\n", n);
+      static bool warned = false;
+      if (!warned) {
+        warned = true;
+        fprintf(stderr, "[polka] CUDA: device buffer full, truncating source to %zu points\n", n);
+      }
       if (n == 0) break;
     }
 
@@ -579,7 +583,11 @@ PipelineResult CudaMergeEngine::merge_pipeline(
     // construction; never write past them even if more sources show up.
     if (n > impl_->max_total_points - total_points) {
       n = impl_->max_total_points - total_points;
-      fprintf(stderr, "[polka] CUDA: device buffer full, truncating source to %zu points\n", n);
+      static bool warned = false;
+      if (!warned) {
+        warned = true;
+        fprintf(stderr, "[polka] CUDA: device buffer full, truncating source to %zu points\n", n);
+      }
       if (n == 0) break;
     }
     src_offset[si] = total_points;

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -668,26 +668,6 @@ void PolkaNode::diagnose_clock_health(const rclcpp::Time & now)
   // leave clock_diagnosed_ unset and re-evaluate on the next tick — no false alarm.
 }
 
-namespace
-{
-constexpr uint64_t kMergePerfLogInterval = 50;
-}
-
-void PolkaNode::log_merge_perf(double us, const char * engine_label)
-{
-  merge_total_us_ += us;
-  merge_max_us_ = std::max(merge_max_us_, us);
-  if (++merge_calls_ % kMergePerfLogInterval == 0) {
-    RCLCPP_INFO(
-      get_logger(),
-      "polka: perf merge [%s]: mean=%.3fms max=%.3fms (over %zu calls)",
-      engine_label, merge_total_us_ / kMergePerfLogInterval / 1000.0,
-      merge_max_us_ / 1000.0, static_cast<size_t>(kMergePerfLogInterval));
-    merge_total_us_ = 0.0;
-    merge_max_us_ = 0.0;
-  }
-}
-
 void PolkaNode::output_callback()
 {
   auto now = this->now();
@@ -831,11 +811,7 @@ void PolkaNode::output_callback()
   if (merge_engine_->is_gpu()) {
     auto pcfg = output_pipeline_.to_pipeline_config(
       scan_pub_ != nullptr, config_.scan_output.flatten);
-    auto merge_t0 = std::chrono::steady_clock::now();
     auto result = merge_engine_->merge_pipeline(inputs, pcfg);
-    log_merge_perf(
-      std::chrono::duration<double, std::micro>(
-        std::chrono::steady_clock::now() - merge_t0).count(), "CUDA");
     if (!result.cloud || result.cloud->empty()) {return;}
 
     last_points_out_ = static_cast<int64_t>(result.cloud->size());
@@ -869,11 +845,7 @@ void PolkaNode::output_callback()
       last_scan_ranges_ = result.scan_ranges;
     }
   } else {
-    auto merge_t0 = std::chrono::steady_clock::now();
     auto merged = merge_engine_->merge(inputs);
-    log_merge_perf(
-      std::chrono::duration<double, std::micro>(
-        std::chrono::steady_clock::now() - merge_t0).count(), "CPU");
     if (!merged || merged->empty()) {return;}
 
     if (config_.point_timestamps.enabled && config_.cloud_output.voxel.enabled) {

--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -28,7 +28,6 @@ namespace polka
 
 namespace
 {
-constexpr uint64_t kPerfLogInterval = 50;
 // Rotation-only deskew fast path: exact-compute the per-point rotation every this
 // many points, linearly interpolate the rest. See deskew_cloud() for the error bound.
 constexpr size_t kDeskewInterpStride = 16;
@@ -336,22 +335,7 @@ void SourceAdapter::pc2_callback(sensor_msgs::msg::PointCloud2::ConstSharedPtr m
   if (deskew_enabled_ && has_timestamp_field_ && get_imu_) {
     auto imu = get_imu_();
     if (imu && imu->valid) {
-      auto t0 = std::chrono::steady_clock::now();
       deskew_cloud(*cloud, *msg, *imu);
-      double us = std::chrono::duration<double, std::micro>(
-        std::chrono::steady_clock::now() - t0).count();
-      deskew_total_us_ += us;
-      deskew_max_us_ = std::max(deskew_max_us_, us);
-      if (++deskew_calls_ % kPerfLogInterval == 0) {
-        RCLCPP_INFO(
-          logger_,
-          "polka: perf source '%s' deskew: mean=%.3fms max=%.3fms (n=%zu pts, over %zu calls)",
-          config_.name.c_str(), deskew_total_us_ / kPerfLogInterval / 1000.0,
-          deskew_max_us_ / 1000.0, cloud->size(),
-          static_cast<size_t>(kPerfLogInterval));
-        deskew_total_us_ = 0.0;
-        deskew_max_us_ = 0.0;
-      }
     }
   }
 


### PR DESCRIPTION
Prepares polka v0.5.0 as a single release PR into humble.

Cleanup: remove perf-only INFO logging (merge and deskew timing accumulators, kMergePerfLogInterval, kPerfLogInterval); guard the two CUDA device-buffer-full stderr warnings so each fires once; drop the dead doc/RUNTIME.md links and the PERF_AUDIT.md citation.

Behavior: source_stale_reuse_window below source_timeout now clamps up with a warning instead of throwing. Defaults unchanged.

Release: bump package.xml to 0.5.0 and add the 0.5.0 CHANGELOG entry.

No ROS toolchain locally, so build and test run in CI.
