### PR TITLE
fix: correct deskew warning and document per-source IMU override

### DIFF
--- a/config/example_params.yaml
+++ b/config/example_params.yaml
@@ -12,6 +12,11 @@
 # Each source needs a valid TF from its frame_id -> output_frame_id.
 # Every parameter (per-source/output filters, IMU deskewing, QoS, per-point
 # timestamps, ...) is documented in config/detailed_params.yaml.
+#
+# IMU deskewing uses a single global motion_compensation.imu_topic by default
+# - the recommended setup for rigid platforms. Articulated platforms (hinged
+# vehicles, turrets, arms) can override sources.<name>.imu_topic per source;
+# see config/example_articulated_imu.yaml for a full example.
 # ============================================================================
 
 polka:

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -68,6 +68,13 @@ bool drift_params_equal(const DiagnosticsConfig & a, const DiagnosticsConfig & b
          a.rate_baseline_sec == b.rate_baseline_sec;
 }
 
+bool any_source_has_own_imu(const std::vector<SourceConfig> & sources)
+{
+  return std::any_of(
+    sources.begin(), sources.end(),
+    [](const SourceConfig & sc) {return !sc.imu_topic.empty();});
+}
+
 }  // namespace
 
 PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
@@ -107,9 +114,15 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
       this, config_.motion_compensation.imu_topic,
       config_.motion_compensation.imu_buffer_size);
   } else if (config_.motion_compensation.enabled) {
-    RCLCPP_WARN(
-      get_logger(),
-      "polka: motion compensation enabled but imu_topic is empty, deskewing will not activate");
+    if (any_source_has_own_imu(config_.sources)) {
+      RCLCPP_INFO(
+        get_logger(),
+        "polka: no global imu_topic; deskewing only sources with a per-source imu_topic");
+    } else {
+      RCLCPP_WARN(
+        get_logger(),
+        "polka: motion compensation enabled but imu_topic is empty, deskewing will not activate");
+    }
   }
 
   for (const auto & src_cfg : config_.sources) {
@@ -322,7 +335,8 @@ void PolkaNode::apply_reconfigure()
     changes.emplace_back("motion_compensation=off");
   }
   if (new_mc.enabled && new_mc.imu_topic.empty() &&
-    !(old_mc.enabled && old_mc.imu_topic.empty()))
+    !(old_mc.enabled && old_mc.imu_topic.empty()) &&
+    !any_source_has_own_imu(new_config.sources))
   {
     RCLCPP_WARN(
       get_logger(),


### PR DESCRIPTION
Closes #4.

The per-source IMU design from #4 was already shipped (PR #13/#14): `sources.<name>.imu_topic`, its own `ImuBuffer`, TF rotation into the sensor frame, no `joint_states` subscription. Verified single-IMU and per-source-only setups both deskew correctly, and a runtime `imu_topic` change rebuilds the adapter.

This closes two remaining gaps:
- Startup/reconfigure warning wrongly said deskewing would not activate whenever the global `imu_topic` was empty, even with per-source overrides set. Now only warns when no source has one.
- `example_params.yaml` never mentioned the override; added a pointer to it and `example_articulated_imu.yaml`.

Flagged, not fixed here: `motion_compensation.imu_frame` is parsed but never read anywhere.

Scope: humble only. This is a log-message and doc fix on top of already-shipped logic, not a new feature, so no jazzy/iron/kilted/lyrical mirror is planned; happy to add one via `scripts/sync-distros.sh` if wanted.

Verified in isaac_ros_dev container: colcon build clean, 167/167 tests pass (38 skipped, GPU-gated), cpplint/uncrustify/flake8 clean.