### PR TITLE
Use point_cloud_transport for PointCloud2 pub/sub

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,16 @@ find_package(diagnostic_msgs REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common filters)
 find_package(Eigen3 REQUIRED)
 
+# Not released for Iron (permanently EOL, never got a build - see MAINTAINING.md);
+# falls back to plain rclcpp PointCloud2 pub/sub there via POLKA_POINT_CLOUD_TRANSPORT_ENABLED.
+find_package(point_cloud_transport QUIET)
+if(point_cloud_transport_FOUND)
+  add_definitions(-DPOLKA_POINT_CLOUD_TRANSPORT_ENABLED)
+  message(STATUS "polka: point_cloud_transport found, PointCloud2 pub/sub uses it")
+else()
+  message(STATUS "polka: point_cloud_transport not found, falling back to plain rclcpp pub/sub")
+endif()
+
 option(WITH_CUDA "Enable CUDA acceleration" ON)
 if(WITH_CUDA)
   include(CheckLanguage)
@@ -75,6 +85,9 @@ if(COMMAND ament_target_dependencies)
     tf2_ros tf2_geometry_msgs tf2_eigen pcl_conversions laser_geometry
     diagnostic_msgs
   )
+  if(point_cloud_transport_FOUND)
+    ament_target_dependencies(polka_core point_cloud_transport)
+  endif()
 else()
   target_link_libraries(polka_core
     rclcpp::rclcpp
@@ -87,6 +100,9 @@ else()
     laser_geometry::laser_geometry
     ${diagnostic_msgs_TARGETS}
   )
+  if(point_cloud_transport_FOUND)
+    target_link_libraries(polka_core point_cloud_transport::point_cloud_transport)
+  endif()
   # pcl_conversions is header-only on some distros and exports no link target;
   # make sure its headers are on the include path regardless.
   target_include_directories(polka_core PUBLIC ${pcl_conversions_INCLUDE_DIRS})

--- a/include/polka/input/source_adapter.hpp
+++ b/include/polka/input/source_adapter.hpp
@@ -29,6 +29,7 @@
 #include "polka/diag/stat_counters.hpp"
 #include "polka/input/imu_buffer.hpp"
 #include "polka/filters/i_filter.hpp"
+#include "polka/util/cloud_transport.hpp"
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
@@ -89,7 +90,7 @@ private:
   SourceConfig config_;
   rclcpp::Logger logger_;
 
-  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr pc2_sub_;
+  CloudSubscriber pc2_sub_;
   rclcpp::Subscription<sensor_msgs::msg::LaserScan>::SharedPtr scan_sub_;
 
   std::shared_ptr<CloudT> buffer_;

--- a/include/polka/polka_node.hpp
+++ b/include/polka/polka_node.hpp
@@ -35,6 +35,7 @@
 #include "polka/merge_engine/i_merge_engine.hpp"
 #include "polka/output/output_pipeline.hpp"
 #include "polka/output/scan_builder.hpp"
+#include "polka/util/cloud_transport.hpp"
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
@@ -115,7 +116,7 @@ private:
   ScanBuilder scan_builder_;
 
   // Output
-  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr cloud_pub_;
+  CloudPublisher cloud_pub_;
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr scan_pub_;
   rclcpp::TimerBase::SharedPtr output_timer_;
 

--- a/include/polka/util/cloud_transport.hpp
+++ b/include/polka/util/cloud_transport.hpp
@@ -1,0 +1,97 @@
+// Copyright 2025 Panav Arpit Raaj <praajarpit@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef POLKA__UTIL__CLOUD_TRANSPORT_HPP_
+#define POLKA__UTIL__CLOUD_TRANSPORT_HPP_
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#ifdef POLKA_POINT_CLOUD_TRANSPORT_ENABLED
+#include <point_cloud_transport/point_cloud_transport.hpp>
+#endif
+
+namespace polka
+{
+
+// Uses point_cloud_transport where available (not released for Iron, see
+// MAINTAINING.md); "raw" transport is wire-compatible with plain PointCloud2.
+#ifdef POLKA_POINT_CLOUD_TRANSPORT_ENABLED
+using CloudPublisher = point_cloud_transport::Publisher;
+using CloudSubscriber = point_cloud_transport::Subscriber;
+#else
+using CloudPublisher = rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr;
+using CloudSubscriber = rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr;
+#endif
+
+inline CloudPublisher create_cloud_publisher(
+  rclcpp::Node * node, const std::string & topic, const rclcpp::QoS & qos)
+{
+#ifdef POLKA_POINT_CLOUD_TRANSPORT_ENABLED
+  // Non-owning alias: called before shared_from_this() is valid in the ctor.
+  auto node_alias = std::shared_ptr<rclcpp::Node>(node, [](rclcpp::Node *) {});
+  return point_cloud_transport::create_publisher(node_alias, topic, qos.get_rmw_qos_profile());
+#else
+  return node->create_publisher<sensor_msgs::msg::PointCloud2>(topic, qos);
+#endif
+}
+
+inline CloudSubscriber create_cloud_subscription(
+  rclcpp::Node * node, const std::string & topic, const rclcpp::QoS & qos,
+  std::function<void(sensor_msgs::msg::PointCloud2::ConstSharedPtr)> callback)
+{
+#ifdef POLKA_POINT_CLOUD_TRANSPORT_ENABLED
+  auto node_alias = std::shared_ptr<rclcpp::Node>(node, [](rclcpp::Node *) {});
+  return point_cloud_transport::create_subscription(
+    node_alias, topic, callback, "raw", qos.get_rmw_qos_profile());
+#else
+  return node->create_subscription<sensor_msgs::msg::PointCloud2>(topic, qos, callback);
+#endif
+}
+
+inline void shutdown_cloud_publisher(CloudPublisher & pub)
+{
+#ifdef POLKA_POINT_CLOUD_TRANSPORT_ENABLED
+  pub.shutdown();
+  pub = CloudPublisher();
+#else
+  pub.reset();
+#endif
+}
+
+inline std::string cloud_publisher_topic(const CloudPublisher & pub)
+{
+#ifdef POLKA_POINT_CLOUD_TRANSPORT_ENABLED
+  return pub.getTopic();
+#else
+  return pub->get_topic_name();
+#endif
+}
+
+inline void publish_cloud(const CloudPublisher & pub, const sensor_msgs::msg::PointCloud2 & msg)
+{
+#ifdef POLKA_POINT_CLOUD_TRANSPORT_ENABLED
+  pub.publish(msg);
+#else
+  pub->publish(msg);
+#endif
+}
+
+}  // namespace polka
+
+#endif  // POLKA__UTIL__CLOUD_TRANSPORT_HPP_

--- a/package.xml
+++ b/package.xml
@@ -24,6 +24,9 @@
   <depend>pcl_conversions</depend>
   <depend>laser_geometry</depend>
   <depend>diagnostic_msgs</depend>
+  <!-- Not released for Iron (permanently EOL, never got a build); polka falls back to
+       plain rclcpp PointCloud2 pub/sub there - see MAINTAINING.md and CMakeLists.txt. -->
+  <depend condition="$ROS_DISTRO != 'iron'">point_cloud_transport</depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>

--- a/src/polka_node.cpp
+++ b/src/polka_node.cpp
@@ -138,8 +138,8 @@ PolkaNode::PolkaNode(const rclcpp::NodeOptions & options)
   scan_builder_.configure(config_.scan_output, config_.output_rate, config_.output_frame_id);
 
   if (config_.cloud_output.enabled) {
-    cloud_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
-      config_.cloud_output.topic, build_qos(config_.cloud_output.qos));
+    cloud_pub_ = create_cloud_publisher(
+      this, config_.cloud_output.topic, build_qos(config_.cloud_output.qos));
   }
   if (config_.scan_output.enabled) {
     scan_pub_ = create_publisher<sensor_msgs::msg::LaserScan>(
@@ -273,7 +273,7 @@ void PolkaNode::apply_reconfigure()
   // Publishers: recreate on topic/QoS change, destroy on disable.
   if (!new_config.cloud_output.enabled) {
     if (cloud_pub_) {
-      cloud_pub_.reset();
+      shutdown_cloud_publisher(cloud_pub_);
       changes.emplace_back("cloud_output=off");
     }
   } else {
@@ -284,8 +284,8 @@ void PolkaNode::apply_reconfigure()
       changes.emplace_back(
         cloud_pub_ ?
         "cloud_output='" + new_config.cloud_output.topic + "'" : "cloud_output=on");
-      cloud_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
-        new_config.cloud_output.topic, build_qos(new_config.cloud_output.qos));
+      cloud_pub_ = create_cloud_publisher(
+        this, new_config.cloud_output.topic, build_qos(new_config.cloud_output.qos));
     }
   }
   if (!new_config.scan_output.enabled) {
@@ -600,7 +600,7 @@ void PolkaNode::diag_callback()
 
   OutputReport out;
   out.engine = merge_engine_->is_gpu() ? "CUDA" : "CPU";
-  out.cloud_topic = cloud_pub_ ? cloud_pub_->get_topic_name() : "";
+  out.cloud_topic = cloud_pub_ ? cloud_publisher_topic(cloud_pub_) : "";
   out.scan_topic = scan_pub_ ? scan_pub_->get_topic_name() : "";
   out.cloud_rates = cloud_out_window_.update(cloud_out_counters_.sample(), now_steady_sec);
   out.scan_rates = scan_out_window_.update(scan_out_counters_.sample(), now_steady_sec);
@@ -750,7 +750,7 @@ void PolkaNode::output_callback()
         msg.header.stamp = last_cloud_stamp_;
         cloud_out_counters_.record(
           msg.data.size() + 72, last_cloud_->size(), last_cloud_->size());
-        cloud_pub_->publish(msg);
+        publish_cloud(cloud_pub_, msg);
         mark_published();
       }
       if (scan_pub_) {
@@ -840,7 +840,7 @@ void PolkaNode::output_callback()
       msg.header.stamp = output_stamp;
       cloud_out_counters_.record(
         msg.data.size() + 72, result.cloud->size(), result.cloud->size());
-      cloud_pub_->publish(msg);
+      publish_cloud(cloud_pub_, msg);
       mark_published();
       std::lock_guard<std::mutex> lock(last_data_mutex_);
       last_cloud_ = result.cloud;
@@ -882,7 +882,7 @@ void PolkaNode::output_callback()
       msg.header.frame_id = config_.output_frame_id;
       msg.header.stamp = output_stamp;
       cloud_out_counters_.record(msg.data.size() + 72, merged->size(), merged->size());
-      cloud_pub_->publish(msg);
+      publish_cloud(cloud_pub_, msg);
       mark_published();
       std::lock_guard<std::mutex> lock(last_data_mutex_);
       last_cloud_ = merged;

--- a/src/source_adapter.cpp
+++ b/src/source_adapter.cpp
@@ -63,8 +63,8 @@ SourceAdapter::SourceAdapter(
 
   // Create subscription based on source type
   if (config.type == SourceType::POINTCLOUD2) {
-    pc2_sub_ = node_->create_subscription<sensor_msgs::msg::PointCloud2>(
-      config.topic, qos,
+    pc2_sub_ = create_cloud_subscription(
+      node_, config.topic, qos,
       std::bind(&SourceAdapter::pc2_callback, this, std::placeholders::_1));
   } else {
     scan_sub_ = node_->create_subscription<sensor_msgs::msg::LaserScan>(


### PR DESCRIPTION
## Summary
Closes #46. PointCloud2 pub/sub now goes through `point_cloud_transport` (raw transport by default), so a topic can opt into a compressed transport (draco, zstd, zlib) just by installing the plugin package, no polka changes needed. Raw transport is wire-compatible with a plain PointCloud2 publisher/subscriber, so this is a no-op for existing setups.

`point_cloud_transport` is not released for Iron (permanently EOL, never got a build). Guarded via `find_package(... QUIET)` in CMake and a `condition` on the `package.xml` depend; Iron falls back to plain rclcpp pub/sub, all other four distros use the transport.

The library's pub/sub constructors want a `shared_ptr<Node>`, which isn't available from `shared_from_this()` inside PolkaNode's/SourceAdapter's own constructors (that throws `bad_weak_ptr` until a shared_ptr already owns the object). Used a non-owning alias shared_ptr (`shared_ptr<Node>(node, no-op deleter)`) instead, scoped to a small `include/polka/util/cloud_transport.hpp` shim so the rest of the code is unchanged.

## Verification
Built and tested against Humble in the project's Isaac ROS dev container (point_cloud_transport 1.0.23 installed):
- `colcon build --packages-select polka`: clean, no new warnings.
- `colcon test --packages-select polka`: 170 tests, 0 errors, 0 failures (includes gtest, uncrustify, cpplint, cppcheck, flake8, xmllint).
- Cross-checked actual Humble/Jazzy/Kilted/Lyrical headers from `ros-perception/point_cloud_transport` on GitHub (not just a local Jazzy copy) to confirm the API used here is stable across all four; Lyrical adds new node-interfaces overloads but keeps the old shared_ptr ones (deprecated, not removed).

## Risks / follow-ups
- No per-source `transport` config knob added (kept to raw, per the issue's scope); a future PR could expose one if compressed transports for sources are wanted.
- Iron support is a permanent fallback, not a gap to close later; there is no released `point_cloud_transport` for Iron on the ROS buildfarm.